### PR TITLE
Support for Gslb Service tunables in GDP

### DIFF
--- a/gslb/cache/controller_obj_cache.go
+++ b/gslb/cache/controller_obj_cache.go
@@ -419,6 +419,9 @@ func parseDescription(description string) ([]string, error) {
 func GetDetailsFromAviGSLBFormatted(gsObj models.GslbService) (uint32, []GSMember, []string, []string, error) {
 	var serverList, domainList, memberObjs, hms []string
 	var gsMembers []GSMember
+	var persistenceProfileRef string
+	var sitePersistenceRequired bool
+	var ttl *int
 
 	domainNames := gsObj.DomainNames
 	if len(domainNames) == 0 {
@@ -459,6 +462,15 @@ func GetDetailsFromAviGSLBFormatted(gsObj models.GslbService) (uint32, []GSMembe
 		}
 		hm := hmObj.Name
 		hms = append(hms, hm)
+	}
+
+	sitePersistenceRequired = *gsObj.SitePersistenceEnabled
+	if sitePersistenceRequired {
+		persistenceProfileRef = *gsObj.ApplicationPersistenceProfileRef
+	}
+	if gsObj.TTL != nil {
+		ttlVal := int(*gsObj.TTL)
+		ttl = &ttlVal
 	}
 
 	for _, val := range groups {
@@ -506,13 +518,15 @@ func GetDetailsFromAviGSLBFormatted(gsObj models.GslbService) (uint32, []GSMembe
 		gslbutils.Errf("object: GSLBService, msg: error while parsing description field: %s", err)
 	}
 	// calculate the checksum
-	checksum := gslbutils.GetGSLBServiceChecksum(serverList, domainList, memberObjs, hms)
+	checksum := gslbutils.GetGSLBServiceChecksum(serverList, domainList, memberObjs, hms,
+		sitePersistenceRequired, persistenceProfileRef, ttl)
 	return checksum, gsMembers, memberObjs, hms, nil
 }
 
 func GetDetailsFromAviGSLB(gslbSvcMap map[string]interface{}) (uint32, []GSMember, []string, []string, error) {
 	var serverList, domainList, memberObjs, hms []string
 	var gsMembers []GSMember
+	var ttl *int
 
 	domainNames, ok := gslbSvcMap["domain_names"].([]interface{})
 	if !ok {
@@ -545,6 +559,26 @@ func GetDetailsFromAviGSLB(gslbSvcMap map[string]interface{}) (uint32, []GSMembe
 		}
 	} else {
 		gslbutils.Debugf("gslbsvcmap: %v, health_monitor_refs absent in gslb service", gslbSvcMap)
+	}
+
+	sitePersistenceEnabled, ok := gslbSvcMap["site_persistence_enabled"].(bool)
+	if !ok {
+		return 0, nil, memberObjs, hms, errors.New("site_persistence_enabled absent in gslb service")
+	}
+
+	var persistenceProfileRef string
+	if sitePersistenceEnabled == true {
+		var ok bool
+		persistenceProfileRef, ok = gslbSvcMap["application_persistence_profile_ref"].(string)
+		if !ok {
+			return 0, nil, memberObjs, hms,
+				errors.New("application_persistence_profile_ref absent in gslb service")
+		}
+	}
+
+	ttlVal, ok := gslbSvcMap["ttl"].(int)
+	if ok {
+		ttl = &ttlVal
 	}
 
 	for _, val := range groups {
@@ -611,7 +645,8 @@ func GetDetailsFromAviGSLB(gslbSvcMap map[string]interface{}) (uint32, []GSMembe
 		gslbutils.Errf("object: GSLBService, msg: error while parsing description field: %s", err)
 	}
 	// calculate the checksum
-	checksum := gslbutils.GetGSLBServiceChecksum(serverList, domainList, memberObjs, hms)
+	checksum := gslbutils.GetGSLBServiceChecksum(serverList, domainList, memberObjs, hms,
+		sitePersistenceEnabled, persistenceProfileRef, ttl)
 	return checksum, gsMembers, memberObjs, hms, nil
 }
 

--- a/gslb/cache/controller_obj_cache.go
+++ b/gslb/cache/controller_obj_cache.go
@@ -420,6 +420,7 @@ func GetDetailsFromAviGSLBFormatted(gsObj models.GslbService) (uint32, []GSMembe
 	var serverList, domainList, memberObjs, hms []string
 	var gsMembers []GSMember
 	var persistenceProfileRef string
+	var persistenceProfileRefPtr *string
 	var sitePersistenceRequired bool
 	var ttl *int
 
@@ -467,6 +468,7 @@ func GetDetailsFromAviGSLBFormatted(gsObj models.GslbService) (uint32, []GSMembe
 	sitePersistenceRequired = *gsObj.SitePersistenceEnabled
 	if sitePersistenceRequired {
 		persistenceProfileRef = *gsObj.ApplicationPersistenceProfileRef
+		persistenceProfileRefPtr = &persistenceProfileRef
 	}
 	if gsObj.TTL != nil {
 		ttlVal := int(*gsObj.TTL)
@@ -519,7 +521,7 @@ func GetDetailsFromAviGSLBFormatted(gsObj models.GslbService) (uint32, []GSMembe
 	}
 	// calculate the checksum
 	checksum := gslbutils.GetGSLBServiceChecksum(serverList, domainList, memberObjs, hms,
-		sitePersistenceRequired, persistenceProfileRef, ttl)
+		persistenceProfileRefPtr, ttl)
 	return checksum, gsMembers, memberObjs, hms, nil
 }
 
@@ -567,6 +569,7 @@ func GetDetailsFromAviGSLB(gslbSvcMap map[string]interface{}) (uint32, []GSMembe
 	}
 
 	var persistenceProfileRef string
+	var persistenceProfileRefPtr *string
 	if sitePersistenceEnabled == true {
 		var ok bool
 		persistenceProfileRef, ok = gslbSvcMap["application_persistence_profile_ref"].(string)
@@ -574,6 +577,7 @@ func GetDetailsFromAviGSLB(gslbSvcMap map[string]interface{}) (uint32, []GSMembe
 			return 0, nil, memberObjs, hms,
 				errors.New("application_persistence_profile_ref absent in gslb service")
 		}
+		persistenceProfileRefPtr = &persistenceProfileRef
 	}
 
 	ttlVal, ok := gslbSvcMap["ttl"].(int)
@@ -646,7 +650,7 @@ func GetDetailsFromAviGSLB(gslbSvcMap map[string]interface{}) (uint32, []GSMembe
 	}
 	// calculate the checksum
 	checksum := gslbutils.GetGSLBServiceChecksum(serverList, domainList, memberObjs, hms,
-		sitePersistenceEnabled, persistenceProfileRef, ttl)
+		persistenceProfileRefPtr, ttl)
 	return checksum, gsMembers, memberObjs, hms, nil
 }
 

--- a/gslb/gslbutils/gdputils.go
+++ b/gslb/gslbutils/gdputils.go
@@ -17,6 +17,7 @@ package gslbutils
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"sync"
 
@@ -62,13 +63,6 @@ var (
 	gfOnce sync.Once
 )
 
-const (
-	// SyncTypeVirtualServices only syncs the virtual service uuids with the controller uuids.
-	SyncTypeVirtualServices = 0
-	// SyncTypeThirdPartyVips syncs the IP addresses present in the ingress/service/route objects.
-	SyncTypeThirdPartyVips = 1
-)
-
 // ClusterProperties contains the properties for a cluster.
 type ClusterProperties struct {
 	// SyncVipsOnly advises AMKO to sync only the VIPs of the member objects of a GS
@@ -87,7 +81,13 @@ type GlobalFilter struct {
 	// ApplicableClusters contain the list of clusters on which the filters
 	// will be applicable
 	ApplicableClusters map[string]ClusterProperties
-	Checksum           uint32
+	// List of health monitors to be attached to all the GSs
+	HealthMonitorRefs []string
+	// Site Persistence properties to be applied to all the GSs
+	SitePersistence gdpv1alpha2.SitePersistence
+	// Time To Live value for each fqdn
+	TTL      *int
+	Checksum uint32
 	// Respective filters for the namespaces.
 	// NSFilterMap map[string]*NSFilter
 	// GlobalLock is locked before accessing any of the filters.
@@ -144,6 +144,31 @@ func (gf *GlobalFilter) AddNSToNSFilter(cname, ns string) error {
 	gf.NSFilter.AddNS(cname, ns)
 
 	return nil
+}
+
+func (gf *GlobalFilter) GetAviHmRefs() []string {
+	gf.GlobalLock.RLock()
+	defer gf.GlobalLock.RUnlock()
+
+	aviHmRefs := make([]string, len(gf.HealthMonitorRefs))
+	copy(aviHmRefs, gf.HealthMonitorRefs)
+	return aviHmRefs
+}
+
+func (gf *GlobalFilter) GetSitePersistence() string {
+	gf.GlobalLock.RLock()
+	defer gf.GlobalLock.RUnlock()
+	if gf.SitePersistence.Enabled {
+		return gf.SitePersistence.ProfileRef
+	}
+	return ""
+}
+
+func (gf *GlobalFilter) GetTTL() *int {
+	gf.GlobalLock.RLock()
+	defer gf.GlobalLock.RUnlock()
+
+	return gf.TTL
 }
 
 type AppFilter struct {
@@ -250,12 +275,24 @@ func (gf *GlobalFilter) AddToFilter(gdp *gdpv1alpha2.GlobalDeploymentPolicy) {
 		}
 		gf.TrafficSplit = append(gf.TrafficSplit, ct)
 	}
+
+	if len(gdp.Spec.HealthMonitorRefs) > 0 {
+		gf.HealthMonitorRefs = make([]string, len(gdp.Spec.HealthMonitorRefs))
+		copy(gf.HealthMonitorRefs, gdp.Spec.HealthMonitorRefs)
+	}
+
+	gf.TTL = gdp.Spec.TTL
+	// The below copies by value as there are no non-primitive members inside SitePersistence
+	// struct.
+	gf.SitePersistence = gdp.Spec.SitePersistence
+
 	gf.ComputeChecksum()
 	Logf("ns: %s, object: NSFilter, msg: added/changed the global filter", gdp.ObjectMeta.Namespace)
 }
 
 func (gf *GlobalFilter) ComputeChecksum() {
 	var cksum uint32
+	var hmRefs []string
 
 	if gf.AppFilter != nil {
 		cksum += utils.Hash(gf.AppFilter.Key + gf.AppFilter.Value)
@@ -269,6 +306,20 @@ func (gf *GlobalFilter) ComputeChecksum() {
 	for _, ts := range gf.TrafficSplit {
 		cksum += utils.Hash(ts.ClusterName + strconv.Itoa(int(ts.Weight)))
 	}
+	if gf.SitePersistence.Enabled {
+		cksum += utils.Hash(utils.Stringify(gf.SitePersistence.Enabled)) +
+			utils.Hash(utils.Stringify(gf.SitePersistence.ProfileRef))
+	}
+	if gf.TTL != nil {
+		cksum += utils.Hash(utils.Stringify(*gf.TTL))
+	}
+	if len(gf.HealthMonitorRefs) > 0 {
+		hmRefs = make([]string, len(gf.HealthMonitorRefs))
+		copy(hmRefs, gf.HealthMonitorRefs)
+		sort.Strings(hmRefs)
+		cksum += utils.Hash(utils.Stringify(hmRefs))
+	}
+
 	gf.Checksum = cksum
 }
 
@@ -363,6 +414,54 @@ func isSyncTypeChanged(new, old *gdpv1alpha2.GlobalDeploymentPolicy) []string {
 	return clustersToBeSynced
 }
 
+func isHmRefsChanged(new, old *gdpv1alpha2.GlobalDeploymentPolicy) bool {
+	if len(old.Spec.HealthMonitorRefs) != len(new.Spec.HealthMonitorRefs) {
+		return true
+	}
+	oldHmRefs := make(map[string]struct{})
+	for _, hmRef := range old.Spec.HealthMonitorRefs {
+		oldHmRefs[hmRef] = struct{}{}
+	}
+	for _, hmRef := range new.Spec.HealthMonitorRefs {
+		if _, exists := oldHmRefs[hmRef]; !exists {
+			return true
+		}
+	}
+	return false
+}
+
+func isSitePersistenceChanged(new, old *gdpv1alpha2.GlobalDeploymentPolicy) bool {
+	newSp := new.Spec.SitePersistence
+	oldSp := old.Spec.SitePersistence
+	if (newSp.Enabled == oldSp.Enabled) && (newSp.Enabled == true) {
+		// if both are true, we check the profile ref value
+		if newSp.ProfileRef != oldSp.ProfileRef {
+			return true
+		}
+		return false
+	} else if newSp.Enabled != oldSp.Enabled {
+		// else, check for any change in the enabled property
+		return true
+	}
+	return false
+}
+
+func isTTLChanged(new, old *gdpv1alpha2.GlobalDeploymentPolicy) bool {
+	if new.Spec.TTL == nil && old.Spec.TTL != nil {
+		return true
+	} else if new.Spec.TTL != nil && old.Spec.TTL == nil {
+		return true
+	} else if new.Spec.TTL != nil && old.Spec.TTL != nil && *new.Spec.TTL != *old.Spec.TTL {
+		return true
+	}
+	return false
+}
+
+func isAllGSPropertyChanged(new, old *gdpv1alpha2.GlobalDeploymentPolicy) bool {
+	return isHmRefsChanged(old, new) || isSitePersistenceChanged(old, new) ||
+		isTTLChanged(old, new) || isTrafficWeightChanged(new, old)
+}
+
 // UpdateGlobalFilter takes two arguments: the old and the new GDP objects, and verifies
 // whether a change is required to any of the filters. If yes, it changes either the cluster
 // filter or one of the namespace filters.
@@ -387,11 +486,14 @@ func (gf *GlobalFilter) UpdateGlobalFilter(oldGDP, newGDP *gdpv1alpha2.GlobalDep
 	gf.NSFilter = nf.NSFilter
 	gf.TrafficSplit = nf.TrafficSplit
 	gf.ApplicableClusters = nf.ApplicableClusters
+	gf.TTL = nf.TTL
+	gf.SitePersistence = nf.SitePersistence
+	gf.HealthMonitorRefs = nf.HealthMonitorRefs
 	gf.Checksum = nf.Checksum
 
-	trafficWeightChanged := isTrafficWeightChanged(newGDP, oldGDP)
 	clustersToBeSynced := isSyncTypeChanged(newGDP, oldGDP)
-	return true, trafficWeightChanged, clustersToBeSynced
+
+	return true, isAllGSPropertyChanged(newGDP, oldGDP), clustersToBeSynced
 }
 
 // DeleteFromGlobalFilter deletes a filter pertaining to gdp.
@@ -414,6 +516,9 @@ func GetNewGlobalFilter() *GlobalFilter {
 		NSFilter:           nil,
 		TrafficSplit:       []ClusterTraffic{},
 		ApplicableClusters: make(map[string]ClusterProperties),
+		HealthMonitorRefs:  []string{},
+		TTL:                nil,
+		SitePersistence:    gdpv1alpha2.SitePersistence{Enabled: false, ProfileRef: ""},
 	}
 	return gf
 }

--- a/gslb/gslbutils/gslbutils.go
+++ b/gslb/gslbutils/gslbutils.go
@@ -93,6 +93,9 @@ const (
 
 	// Timeout for rest operations
 	RestTimeoutSecs = 600
+
+	// Env vars
+	GslbLeader = "GSLB_CTRL_IP_ADDRESS"
 )
 
 // InformersPerCluster is the number of informers per cluster
@@ -269,7 +272,8 @@ var (
 	RejectedNSStore      *ObjectStore
 )
 
-func GetGSLBServiceChecksum(serverList, domainList, memberObjs, hmNames []string) uint32 {
+func GetGSLBServiceChecksum(serverList, domainList, memberObjs, hmNames []string, sitePersistenceEnabled bool,
+	persistenceProfileRef string, ttl *int) uint32 {
 
 	sort.Strings(serverList)
 	sort.Strings(domainList)
@@ -277,10 +281,21 @@ func GetGSLBServiceChecksum(serverList, domainList, memberObjs, hmNames []string
 	sort.Strings(hmNames)
 
 	// checksum has to take into consideration the non-path HMs and the path based HMs
-	return utils.Hash(utils.Stringify(serverList)) +
+	cksum := utils.Hash(utils.Stringify(serverList)) +
 		utils.Hash(utils.Stringify(domainList)) +
 		utils.Hash(utils.Stringify(memberObjs)) +
 		utils.Hash(utils.Stringify(hmNames))
+	if ttl != nil {
+		cksum += utils.Hash(utils.Stringify(*ttl))
+	}
+	// TODO: verify if this affects the existing GSs
+
+	cksum += utils.Hash(utils.Stringify(sitePersistenceEnabled))
+	if sitePersistenceEnabled {
+		cksum += utils.Hash(persistenceProfileRef)
+	}
+
+	return cksum
 }
 
 func GetGSLBHmChecksum(name, hmType string, port int32) uint32 {

--- a/gslb/gslbutils/gslbutils.go
+++ b/gslb/gslbutils/gslbutils.go
@@ -272,8 +272,8 @@ var (
 	RejectedNSStore      *ObjectStore
 )
 
-func GetGSLBServiceChecksum(serverList, domainList, memberObjs, hmNames []string, sitePersistenceEnabled bool,
-	persistenceProfileRef string, ttl *int) uint32 {
+func GetGSLBServiceChecksum(serverList, domainList, memberObjs, hmNames []string,
+	persistenceProfileRef *string, ttl *int) uint32 {
 
 	sort.Strings(serverList)
 	sort.Strings(domainList)
@@ -290,11 +290,9 @@ func GetGSLBServiceChecksum(serverList, domainList, memberObjs, hmNames []string
 	}
 	// TODO: verify if this affects the existing GSs
 
-	cksum += utils.Hash(utils.Stringify(sitePersistenceEnabled))
-	if sitePersistenceEnabled {
-		cksum += utils.Hash(persistenceProfileRef)
+	if persistenceProfileRef != nil {
+		cksum += utils.Hash(*persistenceProfileRef)
 	}
-
 	return cksum
 }
 

--- a/gslb/ingestion/gdp_controller.go
+++ b/gslb/ingestion/gdp_controller.go
@@ -315,10 +315,8 @@ func GDPSanityChecks(gdp *gdpalphav2.GlobalDeploymentPolicy) error {
 	}
 
 	// Site persistence check
-	if gdp.Spec.SitePersistence.Enabled == true {
-		if gdp.Spec.SitePersistence.ProfileRef == "" {
-			return fmt.Errorf("Site Persistence is enabled but no profile refs provided")
-		}
+	if gdp.Spec.SitePersistenceRef != nil && *gdp.Spec.SitePersistenceRef == "" {
+		return fmt.Errorf("empty string as site persistence reference not supported")
 	}
 	return nil
 }

--- a/gslb/nodes/avi_model_nodes.go
+++ b/gslb/nodes/avi_model_nodes.go
@@ -21,6 +21,7 @@ import (
 	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/gslbutils"
 	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/k8sobjects"
 
+	gdpv1alpha1 "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/apis/amko/v1alpha1"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 )
 
@@ -144,11 +145,14 @@ type AviGSObjectGraph struct {
 	Tenant      string
 	DomainNames []string
 	// MemberObjs is a list of K8s/openshift objects from which this AviGS was built.
-	MemberObjs    []AviGSK8sObj
-	GraphChecksum uint32
-	RetryCount    int
-	Hm            HealthMonitor
-	Lock          sync.RWMutex
+	MemberObjs      []AviGSK8sObj
+	GraphChecksum   uint32
+	RetryCount      int
+	Hm              HealthMonitor
+	HmRefs          []string
+	SitePersistence gdpv1alpha1.SitePersistence
+	TTL             *int
+	Lock            sync.RWMutex
 }
 
 func (v *AviGSObjectGraph) SetRetryCounter(num ...int) {
@@ -202,12 +206,19 @@ func (v *AviGSObjectGraph) CalculateChecksum() {
 	}
 
 	hmNames := []string{}
-	if v.Hm.Name != "" {
-		hmNames = append(hmNames, v.Hm.Name)
+	if len(v.HmRefs) > 0 {
+		if v.Hm.Name != "" {
+			hmNames = append(hmNames, v.Hm.Name)
+		} else {
+			hmNames = v.Hm.PathNames
+		}
 	} else {
-		hmNames = v.Hm.PathNames
+		hmNames = make([]string, len(v.HmRefs))
+		copy(hmNames, v.HmRefs)
 	}
-	v.GraphChecksum = gslbutils.GetGSLBServiceChecksum(memberAddrs, v.DomainNames, memberObjs, hmNames)
+
+	v.GraphChecksum = gslbutils.GetGSLBServiceChecksum(memberAddrs, v.DomainNames, memberObjs, hmNames,
+		v.SitePersistence.Enabled, v.SitePersistence.ProfileRef, v.TTL)
 }
 
 // GetMemberRouteList returns a list of member objects
@@ -351,7 +362,14 @@ func (v *AviGSObjectGraph) ConstructAviGSGraph(gsName, key string, metaObj k8sob
 	v.DomainNames = hosts
 	v.MemberObjs = memberRoutes
 	v.RetryCount = gslbutils.DefaultRetryCount
-
+	v.HmRefs = gf.GetAviHmRefs()
+	sp := gf.GetSitePersistence()
+	if sp != "" {
+		v.SitePersistence = gdpv1alpha1.SitePersistence{Enabled: true, ProfileRef: sp}
+	} else {
+		v.SitePersistence = gdpv1alpha1.SitePersistence{Enabled: false}
+	}
+	v.TTL = gf.GetTTL()
 	v.buildHmPathList()
 	// Determine the health monitor(s) for this GS
 	v.buildAndAttachHealthMonitors(metaObj, key)
@@ -399,6 +417,7 @@ func (v *AviGSObjectGraph) checkAndUpdateNonPathHealthMonitor(objType string, is
 }
 
 func (v *AviGSObjectGraph) updateGSHmPathListAndProtocol() {
+	// build the path based health monitor list
 	v.buildHmPathList()
 	gslbutils.Debugf("gsName: %s, added path HMs to the gslb hm path list, path hm list: %v", v.Name, v.Hm.PathNames)
 
@@ -428,6 +447,22 @@ func (v *AviGSObjectGraph) UpdateGSMember(metaObj k8sobjects.MetaObject, weight 
 	var svcPort int32
 	var svcProtocol, objType string
 
+	gf := gslbutils.GetGlobalFilter()
+
+	// Update the GS fields
+	if ttl := gf.GetTTL(); ttl != nil {
+		v.TTL = ttl
+	}
+
+	// We are just looking at the profile ref, because if it is empty, that means,
+	// site persistence is disabled. This is a non-ambiguous case as the user is
+	// not allowed to put an empty ref for persistence profile is site persistence
+	// is enabled.
+	if profileRef := gf.GetSitePersistence(); profileRef != "" {
+		v.SitePersistence.Enabled = true
+		v.SitePersistence.ProfileRef = profileRef
+	}
+
 	paths, err := metaObj.GetPaths()
 	if err != nil {
 		// for LB type services and passthrough routes
@@ -441,12 +476,29 @@ func (v *AviGSObjectGraph) UpdateGSMember(metaObj k8sobjects.MetaObject, weight 
 	}
 
 	cname := metaObj.GetCluster()
-	gf := gslbutils.GetGlobalFilter()
 	syncVIPOnly, err := gf.IsClusterSyncVIPOnly(cname)
 	if err != nil {
 		gslbutils.Errf("gsName: %s, cluster: %s, msg: couldn't find the sync type for member: %v",
 			v.Name, cname, err)
 		return
+	}
+	// custom health monitor refs and the default path/non-path based health monitors are an ex-or
+	// of each other.
+	// Transition cases:
+	// 1. If user has provided Hm refs via the GDP object, remove the default Hms from the GS graph.
+	//    Add the user provided Hm refs to the GS graph.
+	// 2. If user hasn't provided any Hm refs in the GDP object, add the default Hm, and remove the
+	//    pre-existing Hm refs from the GS graph (if any).
+	var userProvidedHmRefs bool
+	hmRefs := gf.GetAviHmRefs()
+	if len(hmRefs) > 0 {
+		v.HmRefs = make([]string, len(hmRefs))
+		copy(v.HmRefs, hmRefs)
+		// set the previous path based health monitor to empty
+		v.Hm = HealthMonitor{}
+		userProvidedHmRefs = true
+	} else {
+		v.HmRefs = []string{}
 	}
 
 	// if the member with the "ipAddr" exists, then just update the weight, else add a new member
@@ -478,7 +530,9 @@ func (v *AviGSObjectGraph) UpdateGSMember(metaObj k8sobjects.MetaObject, weight 
 		if objType == gslbutils.SvcType || metaObj.IsPassthrough() {
 			v.MemberObjs[idx].Port = svcPort
 			v.MemberObjs[idx].Proto = svcProtocol
-			v.checkAndUpdateNonPathHealthMonitor(metaObj.GetType(), metaObj.IsPassthrough())
+			if !userProvidedHmRefs {
+				v.checkAndUpdateNonPathHealthMonitor(metaObj.GetType(), metaObj.IsPassthrough())
+			}
 		} else {
 			tls, err := metaObj.GetTLS()
 			if err != nil {
@@ -487,7 +541,9 @@ func (v *AviGSObjectGraph) UpdateGSMember(metaObj k8sobjects.MetaObject, weight 
 			}
 			v.MemberObjs[idx].TLS = tls
 			v.MemberObjs[idx].Paths = paths
-			v.updateGSHmPathListAndProtocol()
+			if !userProvidedHmRefs {
+				v.updateGSHmPathListAndProtocol()
+			}
 		}
 		return
 	}
@@ -649,6 +705,14 @@ func (v *AviGSObjectGraph) GetCopy() *AviGSObjectGraph {
 		RetryCount:    v.RetryCount,
 		Hm:            v.Hm.getCopy(),
 	}
+	var ttl int
+	if v.TTL != nil {
+		ttl = *v.TTL
+	}
+	gsObjCopy.TTL = &ttl
+	gsObjCopy.HmRefs = make([]string, len(v.HmRefs))
+	copy(gsObjCopy.HmRefs, v.HmRefs)
+	gsObjCopy.SitePersistence = v.SitePersistence
 
 	gsObjCopy.MemberObjs = make([]AviGSK8sObj, 0)
 	for _, memberObj := range v.MemberObjs {

--- a/gslb/nodes/dq_ingestion.go
+++ b/gslb/nodes/dq_ingestion.go
@@ -152,7 +152,7 @@ func AddUpdateObjOperation(key, cname, ns, objType, objName string, wq *utils.Wo
 		prevHmChecksum := gsGraph.GetHmChecksum()
 		// since the object was found, fetch the current checksum
 		prevChecksum = gsGraph.GetChecksum()
-		// GSGraph found, so, only need to update the member of the GSGraph's GSNode
+		// Update the member of the GSGraph's GSNode
 		aviGS.(*AviGSObjectGraph).UpdateGSMember(metaObj, memberWeight)
 		// Get the new checksum after the updates
 		newChecksum = gsGraph.GetChecksum()

--- a/gslb/rest/dq_nodes.go
+++ b/gslb/rest/dq_nodes.go
@@ -164,8 +164,18 @@ func (restOp *RestOperations) getHmPathDiff(aviGSGraph *nodes.AviGSObjectGraph, 
 		return toBeAdded, toBeDeleted
 	}
 
+	// create a map of health monitors in the existing GS object and the new GS object
+	existingHms := make(map[string]struct{})
+	for _, hmName := range gsCacheObj.HealthMonitorNames {
+		existingHms[hmName] = struct{}{}
+	}
+	newHms := make(map[string]struct{})
 	for _, hmName := range hmNameList {
-		if !gslbutils.PresentInList(hmName, gsCacheObj.HealthMonitorNames) {
+		newHms[hmName] = struct{}{}
+	}
+
+	for _, hmName := range hmNameList {
+		if _, exists := existingHms[hmName]; !exists {
 			toBeAdded = append(toBeAdded, hmName)
 		}
 	}
@@ -174,7 +184,7 @@ func (restOp *RestOperations) getHmPathDiff(aviGSGraph *nodes.AviGSObjectGraph, 
 		if path == "" {
 			continue
 		}
-		if !gslbutils.PresentInList(gsHmName, hmNameList) {
+		if _, exists := newHms[gsHmName]; !exists {
 			toBeDeleted = append(toBeDeleted, gsHmName)
 		}
 	}
@@ -322,10 +332,16 @@ func (restOp *RestOperations) RestOperation(gsName, tenant string, aviGSGraph *n
 	var err error
 	if gsCacheObj != nil {
 		if len(pathNames) > 0 {
-			// path based HMs
+			// path based default HMs
 			err = restOp.createOrDeletePathHm(aviGSGraph, gsCacheObj, key, gsKey)
-		} else {
+		} else if aviGSGraph.Hm.Protocol != "" {
+			// non-path based default Hms
 			err = restOp.createOrUpdateNonPathHm(aviGSGraph, gsCacheObj, gsKey, key)
+		} else {
+			// user provided custom HM Refs
+			gslbutils.Logf("key: %s, msg: user provided HM refs will be attached to GS", gsKey)
+			restOp.updateGsIfRequired(aviGSGraph, gsCacheObj, gsKey, key)
+			restOp.deleteAllStaleHMsForGS(gsKey.Tenant + "/" + gsKey.Name)
 		}
 		if err != nil {
 			// the key for this graph would have been already published to the retry queue, so just return
@@ -335,7 +351,7 @@ func (restOp *RestOperations) RestOperation(gsName, tenant string, aviGSGraph *n
 		restOp.updateGsIfRequired(aviGSGraph, gsCacheObj, gsKey, key)
 		return
 	}
-	// its a post operation for a GS
+	// its a POST operation for a GS
 	// first, see if we need new health monitor(s)
 
 	gslbutils.Debugf("key: %s, pathList: %v, msg: path based HM name list of the GS", key, pathNames)
@@ -744,6 +760,7 @@ func (restOp *RestOperations) AviGSBuild(gsMeta *nodes.AviGSObjectGraph, restMet
 	// description field needs references
 	var gslbPoolMembers []*avimodels.GslbPoolMember
 	var gslbSvcGroups []*avimodels.GslbPool
+	var persistenceProfileRef string
 	memberObjs := gsMeta.GetUniqueMemberObjs()
 	for _, member := range memberObjs {
 		if member.IPAddr == "" {
@@ -793,45 +810,66 @@ func (restOp *RestOperations) AviGSBuild(gsMeta *nodes.AviGSObjectGraph, restMet
 	gsName := gsMeta.Name
 	poolAlgorithm := "GSLB_SERVICE_ALGORITHM_PRIORITY"
 	resolveCname := false
-	sitePersistenceEnabled := false
+	sitePersistenceEnabled := gsMeta.SitePersistence.Enabled
+	if gsMeta.SitePersistence.Enabled {
+		persistenceProfileRef = "/api/applicationpersistenceprofile?name=" + gsMeta.SitePersistence.ProfileRef
+	}
 	tenantRef := gslbutils.GetAviAdminTenantRef()
 	useEdnsClientSubnet := true
 	wildcardMatch := false
 	description := strings.Join(gsMeta.GetMemberObjList(), ",")
-
-	aviGslbSvc := avimodels.GslbService{
-		ControllerHealthStatusEnabled: &ctrlHealthStatusEnabled,
-		CreatedBy:                     &createdBy,
-		DomainNames:                   gsMeta.DomainNames,
-		Enabled:                       &gsEnabled,
-		Groups:                        gslbSvcGroups,
-		HealthMonitorScope:            &healthMonitorScope,
-		IsFederated:                   &isFederated,
-		MinMembers:                    &minMembers,
-		Name:                          &gsName,
-		PoolAlgorithm:                 &poolAlgorithm,
-		ResolveCname:                  &resolveCname,
-		SitePersistenceEnabled:        &sitePersistenceEnabled,
-		UseEdnsClientSubnet:           &useEdnsClientSubnet,
-		WildcardMatch:                 &wildcardMatch,
-		TenantRef:                     &tenantRef,
-		Description:                   &description,
+	var hmRefs []string
+	if len(gsMeta.HmRefs) > 0 {
+		copy(hmRefs, gsMeta.HmRefs)
+	}
+	var ttl int32
+	if gsMeta.TTL != nil {
+		ttl = int32(*gsMeta.TTL)
 	}
 
-	hmApi := "/api/healthmonitor?name="
+	aviGslbSvc := avimodels.GslbService{
+		ControllerHealthStatusEnabled:    &ctrlHealthStatusEnabled,
+		CreatedBy:                        &createdBy,
+		DomainNames:                      gsMeta.DomainNames,
+		Enabled:                          &gsEnabled,
+		Groups:                           gslbSvcGroups,
+		HealthMonitorScope:               &healthMonitorScope,
+		IsFederated:                      &isFederated,
+		MinMembers:                       &minMembers,
+		Name:                             &gsName,
+		PoolAlgorithm:                    &poolAlgorithm,
+		ResolveCname:                     &resolveCname,
+		SitePersistenceEnabled:           &sitePersistenceEnabled,
+		UseEdnsClientSubnet:              &useEdnsClientSubnet,
+		WildcardMatch:                    &wildcardMatch,
+		TenantRef:                        &tenantRef,
+		Description:                      &description,
+		TTL:                              &ttl,
+		ApplicationPersistenceProfileRef: &persistenceProfileRef,
+	}
 
-	if hmRequired {
+	hmAPI := "/api/healthmonitor?name="
+
+	// Add the default health monitor(s) only if custom health monitor refs are not provided
+	if hmRequired && len(gsMeta.HmRefs) == 0 {
 		// check if path based (HTTP(S)) HMs are required or just a single non-path based (TCP/UDP) HM
 		if len(gsMeta.Hm.PathNames) == 0 {
 			if gsMeta.Hm.Name == "" {
 				gslbutils.Errf("gs %s doesn't have a health monitor", gsMeta.Name)
 			}
-			aviGslbSvc.HealthMonitorRefs = []string{"/api/healthmonitor?name=" + gsMeta.Hm.Name}
+			aviGslbSvc.HealthMonitorRefs = []string{hmAPI + gsMeta.Hm.Name}
 		} else {
 			aviGslbSvc.HealthMonitorRefs = []string{}
 			for _, hmName := range gsMeta.Hm.PathNames {
-				aviGslbSvc.HealthMonitorRefs = append(aviGslbSvc.HealthMonitorRefs, hmApi+hmName)
+				aviGslbSvc.HealthMonitorRefs = append(aviGslbSvc.HealthMonitorRefs, hmAPI+hmName)
 			}
+		}
+	} else if len(gsMeta.HmRefs) > 0 {
+		// Add the custom health monitors here
+		aviGslbSvc.HealthMonitorRefs = []string{}
+		for _, hmName := range gsMeta.HmRefs {
+			aviGslbSvc.HealthMonitorRefs = append(aviGslbSvc.HealthMonitorRefs,
+				hmAPI+hmName)
 		}
 	}
 

--- a/gslb/rest/dq_nodes.go
+++ b/gslb/rest/dq_nodes.go
@@ -845,6 +845,9 @@ func (restOp *RestOperations) AviGSBuild(gsMeta *nodes.AviGSObjectGraph, restMet
 		persistenceProfileRef := "/api/applicationpersistenceprofile?name=" + *gsMeta.SitePersistenceRef
 		aviGslbSvc.SitePersistenceEnabled = &sitePersistenceEnabled
 		aviGslbSvc.ApplicationPersistenceProfileRef = &persistenceProfileRef
+	} else {
+		sitePersistenceEnabled := false
+		aviGslbSvc.SitePersistenceEnabled = &sitePersistenceEnabled
 	}
 
 	hmAPI := "/api/healthmonitor?name="

--- a/gslb/rest/dq_nodes.go
+++ b/gslb/rest/dq_nodes.go
@@ -760,7 +760,6 @@ func (restOp *RestOperations) AviGSBuild(gsMeta *nodes.AviGSObjectGraph, restMet
 	// description field needs references
 	var gslbPoolMembers []*avimodels.GslbPoolMember
 	var gslbSvcGroups []*avimodels.GslbPool
-	var persistenceProfileRef string
 	memberObjs := gsMeta.GetUniqueMemberObjs()
 	for _, member := range memberObjs {
 		if member.IPAddr == "" {
@@ -810,10 +809,6 @@ func (restOp *RestOperations) AviGSBuild(gsMeta *nodes.AviGSObjectGraph, restMet
 	gsName := gsMeta.Name
 	poolAlgorithm := "GSLB_SERVICE_ALGORITHM_PRIORITY"
 	resolveCname := false
-	sitePersistenceEnabled := gsMeta.SitePersistence.Enabled
-	if gsMeta.SitePersistence.Enabled {
-		persistenceProfileRef = "/api/applicationpersistenceprofile?name=" + gsMeta.SitePersistence.ProfileRef
-	}
 	tenantRef := gslbutils.GetAviAdminTenantRef()
 	useEdnsClientSubnet := true
 	wildcardMatch := false
@@ -828,24 +823,28 @@ func (restOp *RestOperations) AviGSBuild(gsMeta *nodes.AviGSObjectGraph, restMet
 	}
 
 	aviGslbSvc := avimodels.GslbService{
-		ControllerHealthStatusEnabled:    &ctrlHealthStatusEnabled,
-		CreatedBy:                        &createdBy,
-		DomainNames:                      gsMeta.DomainNames,
-		Enabled:                          &gsEnabled,
-		Groups:                           gslbSvcGroups,
-		HealthMonitorScope:               &healthMonitorScope,
-		IsFederated:                      &isFederated,
-		MinMembers:                       &minMembers,
-		Name:                             &gsName,
-		PoolAlgorithm:                    &poolAlgorithm,
-		ResolveCname:                     &resolveCname,
-		SitePersistenceEnabled:           &sitePersistenceEnabled,
-		UseEdnsClientSubnet:              &useEdnsClientSubnet,
-		WildcardMatch:                    &wildcardMatch,
-		TenantRef:                        &tenantRef,
-		Description:                      &description,
-		TTL:                              &ttl,
-		ApplicationPersistenceProfileRef: &persistenceProfileRef,
+		ControllerHealthStatusEnabled: &ctrlHealthStatusEnabled,
+		CreatedBy:                     &createdBy,
+		DomainNames:                   gsMeta.DomainNames,
+		Enabled:                       &gsEnabled,
+		Groups:                        gslbSvcGroups,
+		HealthMonitorScope:            &healthMonitorScope,
+		IsFederated:                   &isFederated,
+		MinMembers:                    &minMembers,
+		Name:                          &gsName,
+		PoolAlgorithm:                 &poolAlgorithm,
+		ResolveCname:                  &resolveCname,
+		UseEdnsClientSubnet:           &useEdnsClientSubnet,
+		WildcardMatch:                 &wildcardMatch,
+		TenantRef:                     &tenantRef,
+		Description:                   &description,
+		TTL:                           &ttl,
+	}
+	if gsMeta.SitePersistenceRef != nil {
+		sitePersistenceEnabled := true
+		persistenceProfileRef := "/api/applicationpersistenceprofile?name=" + *gsMeta.SitePersistenceRef
+		aviGslbSvc.SitePersistenceEnabled = &sitePersistenceEnabled
+		aviGslbSvc.ApplicationPersistenceProfileRef = &persistenceProfileRef
 	}
 
 	hmAPI := "/api/healthmonitor?name="

--- a/helm/amko/crds/gdp_def.yaml
+++ b/helm/amko/crds/gdp_def.yaml
@@ -60,13 +60,8 @@ spec:
                 type: integer
                 minimum: 0
                 maximum: 86400
-              sitePersistence:
-                type: object
-                properties:
-                  enabled:
-                    type: boolean
-                  profileRef:
-                    type: string
+              sitePersistenceRef:
+                type: string
               trafficSplit:
                 items:
                   type: object

--- a/helm/amko/crds/gdp_def.yaml
+++ b/helm/amko/crds/gdp_def.yaml
@@ -49,6 +49,24 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+              # gslbAlgorithm:
+              #   type: string
+              #   enum:
+              healthMonitorRefs:
+                type: array
+                items:
+                  type: string
+              ttl:
+                type: integer
+                minimum: 0
+                maximum: 86400
+              sitePersistence:
+                type: object
+                properties:
+                  enabled:
+                    type: boolean
+                  profileRef:
+                    type: string
               trafficSplit:
                 items:
                   type: object

--- a/internal/apis/amko/v1alpha1/types.go
+++ b/internal/apis/amko/v1alpha1/types.go
@@ -141,7 +141,9 @@ type GSLBHostRuleStatus struct {
 	Status string `json:"status,omitempty"`
 }
 
-// SitePersistence
+// SitePersistence has the required properties to enable site persistence for a GS.
+// If it needs to be enabled, `Enabled` must be set to true, and a persistence profile
+// ref has to be specified.
 type SitePersistence struct {
 	Enabled    bool   `json:"enabled,omitempty"`
 	ProfileRef string `json:"profileRef,omitempty"`

--- a/internal/apis/amko/v1alpha2/types.go
+++ b/internal/apis/amko/v1alpha2/types.go
@@ -46,12 +46,12 @@ type GlobalDeploymentPolicyList struct {
 
 // GDPSpec encloses all the properties of a GDP object.
 type GDPSpec struct {
-	MatchRules        MatchRules         `json:"matchRules,omitempty"`
-	MatchClusters     []ClusterProperty  `json:"matchClusters,omitempty"`
-	TrafficSplit      []TrafficSplitElem `json:"trafficSplit,omitempty"`
-	HealthMonitorRefs []string           `json:"healthMonitorRefs,omitempty"`
-	TTL               *int               `json:"ttl,omitempty"`
-	SitePersistence   SitePersistence    `json:"sitePersistence,omitempty"`
+	MatchRules         MatchRules         `json:"matchRules,omitempty"`
+	MatchClusters      []ClusterProperty  `json:"matchClusters,omitempty"`
+	TrafficSplit       []TrafficSplitElem `json:"trafficSplit,omitempty"`
+	HealthMonitorRefs  []string           `json:"healthMonitorRefs,omitempty"`
+	TTL                *int               `json:"ttl,omitempty"`
+	SitePersistenceRef *string            `json:"sitePersistenceRef,omitempty"`
 }
 
 // ClusterProperty specifies all the properties required for a Cluster. Cluster is the cluster
@@ -100,12 +100,4 @@ type TrafficSplitElem struct {
 // GDPStatus gives the current status of the policy object.
 type GDPStatus struct {
 	ErrorStatus string `json:"errorStatus,omitempty"`
-}
-
-// SitePersistence has the required properties to enable site persistence for a GS.
-// If it needs to be enabled, `Enabled` must be set to true, and a persistence profile
-// ref has to be specified.
-type SitePersistence struct {
-	Enabled    bool   `json:"enabled,omitempty"`
-	ProfileRef string `json:"profileRef,omitempty"`
 }

--- a/internal/apis/amko/v1alpha2/types.go
+++ b/internal/apis/amko/v1alpha2/types.go
@@ -46,9 +46,12 @@ type GlobalDeploymentPolicyList struct {
 
 // GDPSpec encloses all the properties of a GDP object.
 type GDPSpec struct {
-	MatchRules    MatchRules         `json:"matchRules,omitempty"`
-	MatchClusters []ClusterProperty  `json:"matchClusters,omitempty"`
-	TrafficSplit  []TrafficSplitElem `json:"trafficSplit,omitempty"`
+	MatchRules        MatchRules         `json:"matchRules,omitempty"`
+	MatchClusters     []ClusterProperty  `json:"matchClusters,omitempty"`
+	TrafficSplit      []TrafficSplitElem `json:"trafficSplit,omitempty"`
+	HealthMonitorRefs []string           `json:"healthMonitorRefs,omitempty"`
+	TTL               *int               `json:"ttl,omitempty"`
+	SitePersistence   SitePersistence    `json:"sitePersistence,omitempty"`
 }
 
 // ClusterProperty specifies all the properties required for a Cluster. Cluster is the cluster
@@ -97,4 +100,12 @@ type TrafficSplitElem struct {
 // GDPStatus gives the current status of the policy object.
 type GDPStatus struct {
 	ErrorStatus string `json:"errorStatus,omitempty"`
+}
+
+// SitePersistence has the required properties to enable site persistence for a GS.
+// If it needs to be enabled, `Enabled` must be set to true, and a persistence profile
+// ref has to be specified.
+type SitePersistence struct {
+	Enabled    bool   `json:"enabled,omitempty"`
+	ProfileRef string `json:"profileRef,omitempty"`
 }


### PR DESCRIPTION
Some tunables that have been added as part of this PR:
1. Health Monitor Refs: Attach one or more custom health monitors which
   are pre-created.
2. Site Persistence: Enable site persistence for all GS objects and
   attach a application persistence profile ref for it.
3. TTL: Now, set the Time To Live field for a particular A record to
   live. If not given, the default value from the DNS VS will be
   inherited.

Changes include:
- CRD changes: GDP object includes the above three fields.
  Expected Behavior:
  i) If one or more health monitor refs are provided, all the GSs will
     these health monitor refs and the default health monitors (if any)
     will be deleted by AMKO. Consequently, if these health monitor
     refs are removed from the GDP object, AMKO will create the default
     health monitors and attach them to the GS objects.
  ii) For site persistence and TTL, all the GSs will use these values
     provided in the GDP object.

- Ingestion layer: All the above properties now become part of the
  global filter. And any change to any of these properties (and
  additionally, the traffic split property) will prompt the ingestion
  layer to send all the selected objects to the graph layer.
  Global filter's checksum includes these new properties if added,
  otherwise, we don't add them to avoid any unnecessary updates.

- Graph layer: These new tunables become part of the AviGSGraph object
  as root level properties. Before we add/update any member of this
  graph, we always update these tunable values.

- Rest layer: We update these GS level tunables in the AviGSBuild()
  function. We also, delete the default HMs (if the user has requested
  to use only custom HM refs). We also update these GS level tunables
  to the controller object cache.