### PR TITLE
Bugfixes and integration testsuite for GDP and GSLB HostRule

### DIFF
--- a/gslb/gslbutils/gdputils.go
+++ b/gslb/gslbutils/gdputils.go
@@ -280,6 +280,7 @@ func (gf *GlobalFilter) AddToFilter(gdp *gdpv1alpha2.GlobalDeploymentPolicy) {
 	}
 
 	gf.TTL = gdp.Spec.TTL
+
 	gf.SitePersistenceRef = gdp.Spec.SitePersistenceRef
 
 	gf.ComputeChecksum()

--- a/gslb/nodes/dq_ingestion.go
+++ b/gslb/nodes/dq_ingestion.go
@@ -326,7 +326,7 @@ func deleteObjOperation(key, cname, ns, objType, objName string, wq *utils.Worke
 		if uniqueMembersLen != newUniqueMemberLen {
 			metaObj.DeleteMapByKey(clusterObj)
 		}
-		gslbutils.Debugf("key: %s, gsMembers: %d, msg: checking if its a GS deletion case", key,
+		gslbutils.Debugf("key: %s, gsMembers: %v, msg: checking if its a GS deletion case", key,
 			aviGS.(*AviGSObjectGraph).GetUniqueMemberObjs())
 		if len(aviGS.(*AviGSObjectGraph).GetUniqueMemberObjs()) == 0 {
 			deleteGs = true

--- a/gslb/test/avimockobjects/ap_mock.json
+++ b/gslb/test/avimockobjects/ap_mock.json
@@ -1,0 +1,114 @@
+{
+    "count": 6,
+    "results": [
+      {
+        "url": "https://10.79.110.246/api/applicationpersistenceprofile/applicationpersistenceprofile-74781064-5a23-43eb-b9ee-1407bb78f8a7",
+        "uuid": "applicationpersistenceprofile-74781064-5a23-43eb-b9ee-1407bb78f8a7",
+        "name": "System-Persistence-Client-IP",
+        "is_federated": false,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1613586349892635",
+        "persistence_type": "PERSISTENCE_TYPE_CLIENT_IP_ADDRESS",
+        "ip_persistence_profile": {
+          "ip_persistent_timeout": 5
+        },
+        "server_hm_down_recovery": "HM_DOWN_PICK_NEW_SERVER"
+      },
+      {
+        "url": "https://10.79.110.246/api/applicationpersistenceprofile/applicationpersistenceprofile-bd4fee08-ccd4-4fb1-ae68-3d9edcbdd9e5",
+        "uuid": "applicationpersistenceprofile-bd4fee08-ccd4-4fb1-ae68-3d9edcbdd9e5",
+        "name": "System-Persistence-Http-Cookie",
+        "is_federated": false,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1613586349971712",
+        "persistence_type": "PERSISTENCE_TYPE_HTTP_COOKIE",
+        "server_hm_down_recovery": "HM_DOWN_PICK_NEW_SERVER",
+        "http_cookie_persistence_profile": {
+          "cookie_name": "BBLAKGZY",
+          "key": [
+            {
+              "name": "5e8f0325-ec6d-4169-a371-c8c220947235",
+              "aes_key": "K1ht66h8IzrEpbTZYr5d7uL9FZ3TeUh2oTYOgKOhFY0="
+            }
+          ]
+        }
+      },
+      {
+        "url": "https://10.79.110.246/api/applicationpersistenceprofile/applicationpersistenceprofile-415df723-2fac-4a09-a84a-cc69eb516e51",
+        "uuid": "applicationpersistenceprofile-415df723-2fac-4a09-a84a-cc69eb516e51",
+        "name": "System-Persistence-Custom-Http-Header",
+        "is_federated": false,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1613586350024038",
+        "persistence_type": "PERSISTENCE_TYPE_CUSTOM_HTTP_HEADER",
+        "hdr_persistence_profile": {
+          "prst_hdr_name": "customhttphdrname"
+        },
+        "server_hm_down_recovery": "HM_DOWN_PICK_NEW_SERVER"
+      },
+      {
+        "url": "https://10.79.110.246/api/applicationpersistenceprofile/applicationpersistenceprofile-00403603-8547-4d2c-b13a-d58b5ff80c63",
+        "uuid": "applicationpersistenceprofile-00403603-8547-4d2c-b13a-d58b5ff80c63",
+        "name": "System-Persistence-App-Cookie",
+        "is_federated": false,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1613586350066653",
+        "persistence_type": "PERSISTENCE_TYPE_APP_COOKIE",
+        "server_hm_down_recovery": "HM_DOWN_PICK_NEW_SERVER",
+        "app_cookie_persistence_profile": {
+          "prst_hdr_name": "customhttpcookiename",
+          "timeout": 20
+        }
+      },
+      {
+        "url": "https://10.79.110.246/api/applicationpersistenceprofile/applicationpersistenceprofile-bee1f0ee-b5b0-48e8-97b2-e600d9bcacb2",
+        "uuid": "applicationpersistenceprofile-bee1f0ee-b5b0-48e8-97b2-e600d9bcacb2",
+        "name": "System-Persistence-TLS",
+        "is_federated": false,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1613586350108226",
+        "persistence_type": "PERSISTENCE_TYPE_TLS",
+        "server_hm_down_recovery": "HM_DOWN_PICK_NEW_SERVER"
+      },
+      {
+        "url": "https://10.79.110.246/api/applicationpersistenceprofile/applicationpersistenceprofile-9e69455d-e129-4b52-8ce8-debadaa7d897",
+        "uuid": "applicationpersistenceprofile-9e69455d-e129-4b52-8ce8-debadaa7d897",
+        "name": "gap-1",
+        "is_federated": true,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1617083500598800",
+        "persistence_type": "PERSISTENCE_TYPE_GSLB_SITE",
+        "server_hm_down_recovery": "HM_DOWN_PICK_NEW_SERVER",
+        "http_cookie_persistence_profile": {
+          "cookie_name": "KIIYYRUJ",
+          "key": [
+            {
+              "name": "1bb4230f-02af-49c1-8fe0-68c329d13a81",
+              "aes_key": "GJX2n77xIrwFvK5dcwYsjS73nf9EIi7ZUV9O9eX7xL0="
+            }
+          ],
+          "always_send_cookie": false
+        }
+      },
+      {
+        "url": "https://10.79.110.246/api/applicationpersistenceprofile/applicationpersistenceprofile-9e69455d-e129-4b52-8ce8-debadaasadsd",
+        "uuid": "applicationpersistenceprofile-9e69455d-e129-4b52-8ce8-debadaasdasdas",
+        "name": "gap-2",
+        "is_federated": true,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1617083500598800",
+        "persistence_type": "PERSISTENCE_TYPE_GSLB_SITE",
+        "server_hm_down_recovery": "HM_DOWN_PICK_NEW_SERVER",
+        "http_cookie_persistence_profile": {
+          "cookie_name": "KIIYYRUJ",
+          "key": [
+            {
+              "name": "1bb4230f-02af-49c1-8fe0-68c329d13a81",
+              "aes_key": "GJX2n77xIrwFvK5dcwYsjS73nf9EIi7ZUV9O9eX7xL0="
+            }
+          ],
+          "always_send_cookie": false
+        }
+      }
+    ]
+  }

--- a/gslb/test/avimockobjects/hm_mock.json
+++ b/gslb/test/avimockobjects/hm_mock.json
@@ -1,0 +1,300 @@
+{
+    "count": 16,
+    "results": [
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-d0a4d080-323e-495e-b010-bb12bd8fe94e",
+        "uuid": "healthmonitor-d0a4d080-323e-495e-b010-bb12bd8fe94e",
+        "name": "System-HTTP",
+        "is_federated": false,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1613586347616643",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 3,
+        "failed_checks": 3,
+        "type": "HEALTH_MONITOR_HTTP",
+        "http_monitor": {
+          "http_request": "HEAD / HTTP/1.0",
+          "http_response_code": [
+            "HTTP_2XX",
+            "HTTP_3XX"
+          ],
+          "exact_http_request": false
+        }
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-49f5a841-679b-408e-8f21-8974da2de842",
+        "uuid": "healthmonitor-49f5a841-679b-408e-8f21-8974da2de842",
+        "name": "System-HTTPS",
+        "is_federated": false,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1613586347663629",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 3,
+        "failed_checks": 3,
+        "type": "HEALTH_MONITOR_HTTPS",
+        "https_monitor": {
+          "http_request": "HEAD / HTTP/1.0",
+          "http_response_code": [
+            "HTTP_2XX",
+            "HTTP_3XX"
+          ],
+          "exact_http_request": false
+        }
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-df3a8903-cf02-42e7-940d-b4b4cd8fe18b",
+        "uuid": "healthmonitor-df3a8903-cf02-42e7-940d-b4b4cd8fe18b",
+        "name": "System-Ping",
+        "is_federated": false,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1613586347709711",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_PING"
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-4e1466ce-18d6-423b-8499-5420f57286d6",
+        "uuid": "healthmonitor-4e1466ce-18d6-423b-8499-5420f57286d6",
+        "name": "System-TCP",
+        "is_federated": false,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1613586347754962",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_TCP",
+        "tcp_monitor": {
+          "tcp_half_open": false
+        }
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-e213aa6a-e630-4023-86aa-6e2168507162",
+        "uuid": "healthmonitor-e213aa6a-e630-4023-86aa-6e2168507162",
+        "name": "System-UDP",
+        "is_federated": false,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1613586347801812",
+        "send_interval": 4,
+        "receive_timeout": 2,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_UDP",
+        "udp_monitor": {
+          "udp_request": "EnterYourRequestDataHere"
+        }
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-8d06d5f2-d5cd-4b4e-9950-0793d11d9569",
+        "uuid": "healthmonitor-8d06d5f2-d5cd-4b4e-9950-0793d11d9569",
+        "name": "System-DNS",
+        "is_federated": false,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1613586347847005",
+        "send_interval": 6,
+        "receive_timeout": 4,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_DNS",
+        "dns_monitor": {
+          "query_name": "www.google.com",
+          "qtype": "DNS_QUERY_TYPE",
+          "rcode": "RCODE_NO_ERROR",
+          "record_type": "DNS_RECORD_A"
+        }
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-061fe889-5855-414f-b7f3-85f1ececb45a",
+        "uuid": "healthmonitor-061fe889-5855-414f-b7f3-85f1ececb45a",
+        "name": "System-Xternal-Perl",
+        "is_federated": false,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1613586347894163",
+        "send_interval": 30,
+        "receive_timeout": 10,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_EXTERNAL",
+        "external_monitor": {
+          "command_code": "#!/usr/bin/perl -w\nmy $ip= $ARGV[0];\nmy $port = $ARGV[1];\nmy $curl_out;\nif ($ip =~ /:/) {\n$curl_out = `curl -v \"[$ip]\":\"$port\" 2>&1`;\n} else {\n$curl_out = `curl -v \"$ip\":\"$port\" 2>&1`;\n}\nif (index($curl_out, \"200 OK\") != -1) {\n    print \"Server is up\n\";\n}\n"
+        }
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-8d13c11a-b1b2-4b41-bd45-77a2459199f2",
+        "uuid": "healthmonitor-8d13c11a-b1b2-4b41-bd45-77a2459199f2",
+        "name": "System-Xternal-Shell",
+        "is_federated": false,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1613586347940842",
+        "send_interval": 30,
+        "receive_timeout": 10,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_EXTERNAL",
+        "external_monitor": {
+          "command_code": "#!/bin/bash\n#curl -v $IP:$PORT >/run/hmuser/$HM_NAME.$IP.$PORT.out\nif [[ $IP =~ : ]];\nthen curl -v [$IP]:$PORT;\nelse curl -v $IP:$PORT;\nfi\n"
+        }
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-9c62f0e4-62b0-4839-ac9e-3995f9a94ab8",
+        "uuid": "healthmonitor-9c62f0e4-62b0-4839-ac9e-3995f9a94ab8",
+        "name": "System-Xternal-Python",
+        "is_federated": false,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1613586347987578",
+        "send_interval": 30,
+        "receive_timeout": 10,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_EXTERNAL",
+        "external_monitor": {
+          "command_code": "#!/usr/bin/python3\nimport sys\nimport http.client\nconn = http.client.HTTPConnection(sys.argv[1]+':'+sys.argv[2])\nconn.request(\"HEAD\", \"/index.html\")\nr1 = conn.getresponse()\nif r1.status == 200:\n    print(r1.status, r1.reason)\n"
+        }
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-cc0493be-6cd8-4d8d-8495-fa078e992133",
+        "uuid": "healthmonitor-cc0493be-6cd8-4d8d-8495-fa078e992133",
+        "name": "System-PingAccessAgent",
+        "is_federated": false,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1613586348042000",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_HTTPS",
+        "https_monitor": {
+          "http_request": "GET /pa/heartbeat.ping HTTP/1.1",
+          "http_response_code": [
+            "HTTP_2XX"
+          ],
+          "ssl_attributes": {
+            "ssl_profile_ref": "https://10.79.110.246/api/sslprofile/sslprofile-c0cefe91-d126-4345-a0f0-9e2e62c886d1"
+          },
+          "exact_http_request": false
+        },
+        "monitor_port": 3000
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-4d421df1-c9e8-4f26-a3e3-88a35db4e0de",
+        "uuid": "healthmonitor-4d421df1-c9e8-4f26-a3e3-88a35db4e0de",
+        "name": "System-GSLB-Ping",
+        "is_federated": true,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1613591338447001",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_PING"
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-756a36e0-8ed8-4887-a0b3-f51a9fc276b6",
+        "uuid": "healthmonitor-756a36e0-8ed8-4887-a0b3-f51a9fc276b6",
+        "name": "System-GSLB-TCP",
+        "is_federated": true,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1613591338471003",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_TCP",
+        "tcp_monitor": {
+          "tcp_half_open": false
+        },
+        "monitor_port": 80
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-bdfcee4c-4baf-4def-ac5b-541422e4af48",
+        "uuid": "healthmonitor-bdfcee4c-4baf-4def-ac5b-541422e4af48",
+        "name": "System-GSLB-HTTP",
+        "is_federated": true,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1613591338486983",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 3,
+        "failed_checks": 3,
+        "type": "HEALTH_MONITOR_HTTP",
+        "http_monitor": {
+          "http_request": "HEAD / HTTP/1.0",
+          "http_response_code": [
+            "HTTP_2XX",
+            "HTTP_3XX"
+          ],
+          "exact_http_request": false
+        },
+        "monitor_port": 80
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-0c260e8d-3d44-4c02-a2b7-b16089b585d1",
+        "uuid": "healthmonitor-0c260e8d-3d44-4c02-a2b7-b16089b585d1",
+        "name": "System-GSLB-HTTPS",
+        "is_federated": true,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1613591338502707",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 3,
+        "failed_checks": 3,
+        "type": "HEALTH_MONITOR_HTTPS",
+        "https_monitor": {
+          "http_request": "HEAD / HTTP/1.0",
+          "http_response_code": [
+            "HTTP_2XX",
+            "HTTP_3XX"
+          ],
+          "exact_http_request": false
+        },
+        "monitor_port": 443
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-7eff8b9f-8619-4b7b-9b18-e76da874685d",
+        "uuid": "healthmonitor-7eff8b9f-8619-4b7b-9b18-e76da874685d",
+        "name": "System-GSLB-UDP",
+        "is_federated": true,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1613591338518184",
+        "send_interval": 4,
+        "receive_timeout": 2,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_UDP",
+        "udp_monitor": {
+          "udp_request": "EnterYourRequestDataHere"
+        },
+        "monitor_port": 443
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-6837ea95-7613-4415-a059-b6e34c39f321",
+        "uuid": "healthmonitor-6837ea95-7613-4415-a059-b6e34c39f321",
+        "name": "my-hm1",
+        "is_federated": true,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1616766136533179",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_PING"
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-6837ea95-7613-4415-a059-b6e34c39f321",
+        "uuid": "healthmonitor-6837ea95-7613-4415-a059-12031209333d",
+        "name": "my-hm2",
+        "is_federated": true,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1616766136533179",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_HTTPS"
+      }
+    ]
+  }

--- a/gslb/test/integration/third_party_vips/gslb_hostrule_test.go
+++ b/gslb/test/integration/third_party_vips/gslb_hostrule_test.go
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package third_party_vips
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/gslbutils"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/nodes"
+	ingestion_test "github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/test/ingestion"
+	gslbalphav1 "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/apis/amko/v1alpha1"
+	gdpalphav2 "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/apis/amko/v1alpha2"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	// k8serrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+var (
+	routeCluster = "oshift"
+	ingCluster   = "k8s"
+)
+
+func addTestGDPWithProperties(t *testing.T, hmRefs []string, ttl *int, sitePersistence *string) *gdpalphav2.GlobalDeploymentPolicy {
+	gdpObj := GetTestDefaultGDPObject()
+	gdpObj.Spec.MatchRules.AppSelector = gdpalphav2.AppSelector{
+		Label: appLabel,
+	}
+	gdpObj.Spec.MatchClusters = []gdpalphav2.ClusterProperty{
+		{Cluster: K8sContext}, {Cluster: OshiftContext},
+	}
+	gdpObj.Spec.HealthMonitorRefs = hmRefs
+	gdpObj.Spec.TTL = ttl
+	gdpObj.Spec.SitePersistenceRef = sitePersistence
+
+	newGDP, err := AddAndVerifyTestGDPSuccess(t, gdpObj)
+	if err != nil {
+		t.Fatalf("error in creating and verifying GDP object %v: %v", newGDP, err)
+	}
+
+	t.Cleanup(func() {
+		DeleteTestGDP(t, gdpObj.Namespace, gdpObj.Name)
+	})
+
+	return newGDP
+}
+
+func getTestGDP(t *testing.T, name, ns string) *gdpalphav2.GlobalDeploymentPolicy {
+	gdp, err := gslbutils.GlobalGdpClient.AmkoV1alpha2().GlobalDeploymentPolicies(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get GDP object %s: %v", name, err)
+	}
+	return gdp
+}
+
+func updateTestGDP(t *testing.T, gdp *gdpalphav2.GlobalDeploymentPolicy) *gdpalphav2.GlobalDeploymentPolicy {
+	newGdp, err := gslbutils.GlobalGdpClient.AmkoV1alpha2().GlobalDeploymentPolicies(gdp.Namespace).Update(context.TODO(), gdp, metav1.UpdateOptions{})
+	// if k8serrors.
+	if err != nil {
+		t.Fatalf("update on GDP %v failed with %v", gdp, err)
+	}
+	VerifyGDPStatus(t, gdp.Namespace, gdp.Name, "success")
+	return newGdp
+}
+
+func addIngressAndRouteObjects(t *testing.T, testPrefix string) (*networkingv1beta1.Ingress, *routev1.Route) {
+	ingName := testPrefix + "def-ing"
+	routeName := testPrefix + "def-route"
+	ns := "default"
+	host := testPrefix + ingestion_test.TestDomain1
+	ingIPAddr := "10.10.100.1"
+	routeIPAddr := "10.10.200.1"
+	ingHostIPMap := map[string]string{host: ingIPAddr}
+
+	t.Cleanup(func() {
+		k8sDeleteIngress(t, clusterClients[K8s], ingName, ns)
+		oshiftDeleteRoute(t, clusterClients[Oshift], routeName, ns)
+	})
+
+	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
+		ingHostIPMap, true)
+	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
+		routeCluster, host, routeIPAddr, true)
+	return ingObj, routeObj
+}
+
+// Add ingress and route objects, set the health monitor ref and verify
+func TestGDPPropertiesForHealthMonitor(t *testing.T) {
+	testPrefix := "gdp-hm-"
+	hmRefs := []string{"my-hm1"}
+
+	oldGDP := addTestGDPWithProperties(t, hmRefs, nil, nil)
+
+	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
+
+	var expectedMembers []nodes.AviGSK8sObj
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g := gomega.NewGomegaWithT(t)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, hmRefs, nil, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Update the GDP object with a new health monitor ref
+	newGDP := getTestGDP(t, oldGDP.Name, oldGDP.Namespace)
+	newGDP.Spec.HealthMonitorRefs = []string{"my-hm2"}
+	updateTestGDP(t, newGDP)
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, hmRefs, nil, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Add ingress and route objects, set the persistence profile and verify
+func TestGDPPropertiesForPersistenceProfile(t *testing.T) {
+	testPrefix := "gdp-sp-"
+	sitePersistence := "gap-1"
+
+	addTestGDPWithProperties(t, nil, nil, &sitePersistence)
+
+	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
+
+	var expectedMembers []nodes.AviGSK8sObj
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g := gomega.NewGomegaWithT(t)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, nil, &sitePersistence,
+			nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Add ingress and route objects, set the TTL and verify
+func TestGDPPropertiesForTTL(t *testing.T) {
+	testPrefix := "gdp-ttl-"
+	ttl := 10
+
+	oldGDP := addTestGDPWithProperties(t, nil, &ttl, nil)
+
+	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
+
+	var expectedMembers []nodes.AviGSK8sObj
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g := gomega.NewGomegaWithT(t)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, nil, nil,
+			&ttl)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	t.Logf("Updating TTL value to 20 seconds")
+	ttl = 20
+	gdpObj := getTestGDP(t, oldGDP.Name, oldGDP.Namespace)
+	gdpObj.Spec.TTL = &ttl
+	updateTestGDP(t, gdpObj)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, nil, nil,
+			&ttl)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Create a GSLBHostRule object and check if the GS properties are overriden with the
+// the properties specified in the GSLB HostRule object.
+func TestGSLBHostRuleCreate(t *testing.T) {
+	testPrefix := "gdp-gslbhr-"
+	gslbHRName := "test-gslb-hr"
+	hmRefs := []string{"my-hm1"}
+	sp := "gap-1"
+	ttl := 10
+
+	addTestGDPWithProperties(t, hmRefs, &ttl, &sp)
+	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
+	var expectedMembers []nodes.AviGSK8sObj
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g := gomega.NewGomegaWithT(t)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, hmRefs, &sp,
+			&ttl)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	hostName := routeObj.Spec.Host
+	gslbHRHmRefs := []string{"my-hm2"}
+	gslbHRTTL := 20
+	addGSLBHostRule(t, gslbHRName, gslbutils.AVISystem, hostName, gslbHRHmRefs, nil, &gslbHRTTL)
+	g.Eventually(func() bool {
+		// Site persistence remains unchanged, as it inherits from the GDP object
+		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, gslbHRHmRefs,
+			&sp, &gslbHRTTL)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Update various properties of the GSLBHostRule object and check if the actions are taken accordingly.
+// TODO: verify addition of 3rd party members via the GSLB Host Rule.
+func TestGSLBHostRuleUpdate(t *testing.T) {
+	testPrefix := "gdp-gslbhru-"
+	gslbHRName := "test-gslb-hr"
+	hmRefs := []string{"my-hm1"}
+	sp := "gap-1"
+	ttl := 10
+
+	addTestGDPWithProperties(t, hmRefs, &ttl, &sp)
+	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
+	var expectedMembers []nodes.AviGSK8sObj
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g := gomega.NewGomegaWithT(t)
+
+	hostName := routeObj.Spec.Host
+	gslbHRHmRefs := []string{"my-hm2"}
+	gslbHRTTL := 20
+	oldGSHR := addGSLBHostRule(t, gslbHRName, gslbutils.AVISystem, hostName, gslbHRHmRefs, nil, &gslbHRTTL)
+	g.Eventually(func() bool {
+		// Site persistence remains unchanged, as it inherits from the GDP object
+		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, gslbHRHmRefs,
+			&sp, &gslbHRTTL)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// add a new site persistence
+	newObj := getGSLBHostRule(t, oldGSHR.Name, oldGSHR.Namespace)
+	newObj.Spec.SitePersistence = &gslbalphav1.SitePersistence{
+		Enabled: false,
+	}
+	updateGSLBHostRule(t, newObj)
+
+	// verify whether site persistence got updated
+	g.Eventually(func() bool {
+		// Site persistence changed and set to nil now
+		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, gslbHRHmRefs,
+			nil, &gslbHRTTL)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// delete the health monitor ref from GSLB Host Rule and check if it is inherited from the
+	newObj = getGSLBHostRule(t, oldGSHR.Name, oldGSHR.Namespace)
+	newObj.Spec.HealthMonitorRefs = nil
+	updateGSLBHostRule(t, newObj)
+
+	// verify whether site persistence got updated
+	g.Eventually(func() bool {
+		// Health monitor refs are deleted, should be inherited from the GDP object
+		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, hmRefs,
+			nil, &gslbHRTTL)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Create a GSLBHostRule object, verify the overriden properties, delete the GSLBHostRule object
+// and see if the GS falls back to the GDP properties.
+func TestGSLBHostRuleDelete(t *testing.T) {
+	testPrefix := "gdp-gslbhrd-"
+	gslbHRName := "test-gslb-hr"
+	hmRefs := []string{"my-hm1"}
+	sp := "gap-1"
+	ttl := 10
+
+	addTestGDPWithProperties(t, hmRefs, &ttl, &sp)
+	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
+	var expectedMembers []nodes.AviGSK8sObj
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g := gomega.NewGomegaWithT(t)
+
+	hostName := routeObj.Spec.Host
+	gslbHRHmRefs := []string{"my-hm2"}
+	gslbHRTTL := 20
+	gsHRObj := addGSLBHostRule(t, gslbHRName, gslbutils.AVISystem, hostName, gslbHRHmRefs, nil, &gslbHRTTL)
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, gslbHRHmRefs,
+			&sp, &gslbHRTTL)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	t.Logf("will delete the gslb host rule object")
+	deleteGSLBHostRule(t, gsHRObj.Name, gsHRObj.Namespace)
+	g.Eventually(func() bool {
+		// TTL and HM refs will fall back to the GDP object
+		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, hmRefs,
+			&sp, &ttl)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}

--- a/gslb/test/integration/third_party_vips/gslb_hostrule_test.go
+++ b/gslb/test/integration/third_party_vips/gslb_hostrule_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	// k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var (
@@ -71,7 +70,6 @@ func getTestGDP(t *testing.T, name, ns string) *gdpalphav2.GlobalDeploymentPolic
 
 func updateTestGDP(t *testing.T, gdp *gdpalphav2.GlobalDeploymentPolicy) *gdpalphav2.GlobalDeploymentPolicy {
 	newGdp, err := gslbutils.GlobalGdpClient.AmkoV1alpha2().GlobalDeploymentPolicies(gdp.Namespace).Update(context.TODO(), gdp, metav1.UpdateOptions{})
-	// if k8serrors.
 	if err != nil {
 		t.Fatalf("update on GDP %v failed with %v", gdp, err)
 	}

--- a/gslb/test/integration/third_party_vips/int_test.go
+++ b/gslb/test/integration/third_party_vips/int_test.go
@@ -30,6 +30,7 @@ import (
 	oshiftclient "github.com/openshift/client-go/route/clientset/versioned"
 	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/gslbutils"
 	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/ingestion"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/nodes"
 	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/test/mockaviserver"
 	gslbalphav1 "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/apis/amko/v1alpha1"
 	gdpalphav2 "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/apis/amko/v1alpha2"
@@ -170,14 +171,12 @@ func SyncFromTestIngestionLayer(key string, wg *sync.WaitGroup) error {
 	gslbutils.Logf("recieved key from ingestion layer: %s", key)
 	ingestionKeyChan <- key
 
-	// call the actual graph layer function
-	// nodes.DequeueIngestion(key)
 	return nil
 }
 
 func SyncFromTestNodesLayer(key string, wg *sync.WaitGroup) error {
 	gslbutils.Logf("recived key from graph layer: %s", key)
-	// graphKeyChan <- key
+	graphKeyChan <- key
 
 	return nil
 }
@@ -191,7 +190,7 @@ func SetUpTestWorkerQueues() {
 	utils.SharedWorkQueue(&ingestionQueueParams, &graphQueueParams)
 
 	ingestionSharedQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
-	ingestionSharedQueue.SyncFunc = SyncFromTestIngestionLayer
+	ingestionSharedQueue.SyncFunc = nodes.SyncFromIngestionLayer
 	ingestionSharedQueue.Run(stopCh, gslbutils.GetWaitGroupFromMap(gslbutils.WGIngestion))
 
 	// Set workers for layer 3 (REST layer)

--- a/gslb/test/mockaviserver/aviserver.go
+++ b/gslb/test/mockaviserver/aviserver.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/avinetworks/sdk/go/models"
 	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/gslbutils"
 )
 
@@ -151,6 +152,8 @@ func SendResponseForObjects(objects []string, w http.ResponseWriter, r *http.Req
 		FeedMockClusterData(w, r)
 	case "gslb":
 		FeedMockGslbData(w, r)
+	case "healthmonitor":
+		FeedMockHMData(w, r)
 	default:
 		w.WriteHeader(http.StatusNotFound)
 		w.Write([]byte(`{"error": "resource not found"}`))
@@ -214,6 +217,100 @@ func FeedMockGslbData(w http.ResponseWriter, r *http.Request) {
 		data, err := ioutil.ReadFile(mockFilePath)
 		if err != nil {
 			gslbutils.Errf("error in reading file: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write(data)
+	}
+}
+
+func FeedMockHMData(w http.ResponseWriter, r *http.Request) {
+	mockFilePath := GetMockFilePath("hm_mock.json")
+	url := r.URL.EscapedPath()
+	object := strings.Split(strings.Trim(url, "/"), "/")
+	if len(object) > 1 && r.Method == "GET" {
+		data, err := ioutil.ReadFile(mockFilePath)
+		if err != nil {
+			gslbutils.Errf("error in reading file: %v", err)
+			w.WriteHeader(404)
+			return
+		}
+		type MockHMData struct {
+			Count   int                    `json:"count"`
+			Results []models.HealthMonitor `json:"results"`
+		}
+		mockHmData := MockHMData{
+			Results: []models.HealthMonitor{},
+		}
+		err = json.Unmarshal([]byte(data), &mockHmData)
+		if err != nil {
+			gslbutils.Errf("error in unmarshalling health monitor data: %v", err)
+			w.WriteHeader(404)
+		}
+		splitData := strings.Split(url, "?name=")
+		if len(splitData) == 2 {
+			// we need a specific hm data
+			for _, hm := range mockHmData.Results {
+				if *hm.Name == splitData[1] {
+					data, err = json.Marshal(hm)
+					if err != nil {
+						gslbutils.Errf("error in marshalling health monitor data: %v", err)
+						w.WriteHeader(404)
+						return
+					}
+					w.WriteHeader(http.StatusOK)
+					w.Write(data)
+					return
+				}
+			}
+			w.WriteHeader(404)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write(data)
+	}
+}
+
+func FeedMockPersistenceData(w http.ResponseWriter, r *http.Request) {
+	mockFilePath := GetMockFilePath("ap_mock.json")
+	url := r.URL.EscapedPath()
+	object := strings.Split(strings.Trim(url, "/"), "/")
+	if len(object) > 1 && r.Method == "GET" {
+		data, err := ioutil.ReadFile(mockFilePath)
+		if err != nil {
+			gslbutils.Errf("error in reading file: %v", err)
+			w.WriteHeader(404)
+			return
+		}
+		type MockHMData struct {
+			Count   int                                    `json:"count"`
+			Results []models.ApplicationPersistenceProfile `json:"results"`
+		}
+		mockHmData := MockHMData{
+			Results: []models.ApplicationPersistenceProfile{},
+		}
+		err = json.Unmarshal([]byte(data), &mockHmData)
+		if err != nil {
+			gslbutils.Errf("error in unmarshalling persistence profile data: %v", err)
+			w.WriteHeader(404)
+		}
+		splitData := strings.Split(url, "?name=")
+		if len(splitData) == 2 {
+			// we need a specific hm data
+			for _, hm := range mockHmData.Results {
+				if *hm.Name == splitData[1] {
+					data, err = json.Marshal(hm)
+					if err != nil {
+						gslbutils.Errf("error in marshalling persistence profile data: %v", err)
+						w.WriteHeader(404)
+						return
+					}
+					w.WriteHeader(http.StatusOK)
+					w.Write(data)
+					return
+				}
+			}
+			w.WriteHeader(404)
+			return
 		}
 		w.WriteHeader(http.StatusOK)
 		w.Write(data)


### PR DESCRIPTION
Fixes:

- While copying the GS graph, TTL value for default cases (where the
  user has specified as nil), was taken as 0. It was because, for `nil`
  cases, we were taking the address of a zero'ed variable.

- If the GSLB HostRule gets deleted by the user, the health monitor ref
  isn't getting reset to the GDP object's health monitor ref(s). Reason
  for this was because, upon deletion, in the graph layer, if we didn't
  find a GSLB Host Rule for an FQDN, we simply logged an error. Its now
  fixed to always update the GS graph, regardless of whether the GSLB Host
  Rule is present or absent.

Integration tests now include:
- Global properties with GDP:
  * Set global properties like TTL, HM Ref(s), Site Persistence and GS
    graph verification.
  * Update the global properties and GS graph verification for the
    relevant updates.

- GS properties with GSLBHostRule:
  * GSLBHostRule create operation with GS properties different from GDP
    object and GS Graph verification.
  * GSLBHostRule update operations with individual properties being
    updated and/or removed. In case of removal of a certain property,
    the GS graph should inherit GDP properties.
  * GSLBHostRule delete operation. GS graph simply inherits all
    properties of the GDP object.

Library functions now include:
- Creating TLS Ingress/route objects.
- Creating/deleting secret objects.
- Creating/deleting/updating GSLB HostRule objects.
- Creating GS member objects out of ingress/route objects