### PR TITLE
Return an error if health monitor is not federated

### DIFF
--- a/gslb/ingestion/gdp_controller.go
+++ b/gslb/ingestion/gdp_controller.go
@@ -317,6 +317,15 @@ func GDPSanityChecks(gdp *gdpalphav2.GlobalDeploymentPolicy) error {
 		}
 	}
 
+	// Health monotor validity
+	if len(gdp.Spec.HealthMonitorRefs) != 0 {
+		for _, hmRef := range gdp.Spec.HealthMonitorRefs {
+			if !isHealthMonitorRefValid(hmRef) {
+				return fmt.Errorf("health monitor ref %s is invalid", hmRef)
+			}
+		}
+	}
+
 	// Site persistence check
 	if gdp.Spec.SitePersistenceRef != nil && *gdp.Spec.SitePersistenceRef == "" {
 		return fmt.Errorf("empty string as site persistence reference not supported")

--- a/gslb/test/avimockobjects/hm_mock.json
+++ b/gslb/test/avimockobjects/hm_mock.json
@@ -295,6 +295,19 @@
         "successful_checks": 2,
         "failed_checks": 2,
         "type": "HEALTH_MONITOR_HTTPS"
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-6837ea95-7613-4415-a059-xxxxxxxxx",
+        "uuid": "healthmonitor-6837ea95-7613-4415-a059-12xxxxxxxx",
+        "name": "my-hm3",
+        "is_federated": false,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1616766136533179",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_HTTPS"
       }
     ]
   }

--- a/gslb/test/integration/third_party_vips/gslb_hostrule_test.go
+++ b/gslb/test/integration/third_party_vips/gslb_hostrule_test.go
@@ -128,7 +128,6 @@ func TestGDPPropertiesForHealthMonitor(t *testing.T) {
 
 // Add ingress and route objects, set an invalid health monitor ref (where the federated value is false)
 func TestGDPPropertiesForInvalidHealthMonitor(t *testing.T) {
-	// testPrefix := "hm-invalid-"
 	hmRefs := []string{"my-hm3"}
 
 	gdpObj := GetTestDefaultGDPObject()

--- a/gslb/test/mockaviserver/aviserver.go
+++ b/gslb/test/mockaviserver/aviserver.go
@@ -225,7 +225,7 @@ func FeedMockGslbData(w http.ResponseWriter, r *http.Request) {
 
 func FeedMockHMData(w http.ResponseWriter, r *http.Request) {
 	mockFilePath := GetMockFilePath("hm_mock.json")
-	url := r.URL.EscapedPath()
+	url := r.URL.String()
 	object := strings.Split(strings.Trim(url, "/"), "/")
 	if len(object) > 1 && r.Method == "GET" {
 		data, err := ioutil.ReadFile(mockFilePath)
@@ -251,7 +251,11 @@ func FeedMockHMData(w http.ResponseWriter, r *http.Request) {
 			// we need a specific hm data
 			for _, hm := range mockHmData.Results {
 				if *hm.Name == splitData[1] {
-					data, err = json.Marshal(hm)
+					responseData := MockHMData{
+						Count:   1,
+						Results: []models.HealthMonitor{hm},
+					}
+					data, err = json.Marshal(responseData)
 					if err != nil {
 						gslbutils.Errf("error in marshalling health monitor data: %v", err)
 						w.WriteHeader(404)
@@ -272,7 +276,7 @@ func FeedMockHMData(w http.ResponseWriter, r *http.Request) {
 
 func FeedMockPersistenceData(w http.ResponseWriter, r *http.Request) {
 	mockFilePath := GetMockFilePath("ap_mock.json")
-	url := r.URL.EscapedPath()
+	url := r.URL.String()
 	object := strings.Split(strings.Trim(url, "/"), "/")
 	if len(object) > 1 && r.Method == "GET" {
 		data, err := ioutil.ReadFile(mockFilePath)
@@ -281,11 +285,11 @@ func FeedMockPersistenceData(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(404)
 			return
 		}
-		type MockHMData struct {
+		type MockAPData struct {
 			Count   int                                    `json:"count"`
 			Results []models.ApplicationPersistenceProfile `json:"results"`
 		}
-		mockHmData := MockHMData{
+		mockHmData := MockAPData{
 			Results: []models.ApplicationPersistenceProfile{},
 		}
 		err = json.Unmarshal([]byte(data), &mockHmData)
@@ -295,10 +299,14 @@ func FeedMockPersistenceData(w http.ResponseWriter, r *http.Request) {
 		}
 		splitData := strings.Split(url, "?name=")
 		if len(splitData) == 2 {
-			// we need a specific hm data
-			for _, hm := range mockHmData.Results {
-				if *hm.Name == splitData[1] {
-					data, err = json.Marshal(hm)
+			// we need a specific persistence profile data
+			for _, ap := range mockHmData.Results {
+				if *ap.Name == splitData[1] {
+					responseData := MockAPData{
+						Count:   1,
+						Results: []models.ApplicationPersistenceProfile{ap},
+					}
+					data, err = json.Marshal(responseData)
 					if err != nil {
 						gslbutils.Errf("error in marshalling persistence profile data: %v", err)
 						w.WriteHeader(404)


### PR DESCRIPTION
- If the ref provided in the GDP/GSLBHostRule object is for a
  non-federated Health monitor object, write an invalid status in the
  GDP or GSLBHostRule object and return.

- Enhance tests to cover invalid HM ref scenarios via GDP/GSLBHostRule.
  This also includes a fix in the mock aviserver where we weren't fetching
  specific health monitor or site persistence objects because of escaped
  URLs.