### PR TITLE
Skip initializing member cluster if HostRule CRD absent

### DIFF
--- a/gslb/ingestion/gslb.go
+++ b/gslb/ingestion/gslb.go
@@ -827,7 +827,8 @@ func InitializeMemberCluster(cfg *restclient.Config, cluster KubeClusterDetails,
 		aviCtrl.hrClientSet = hrClient
 		_, err := hrClient.AkoV1alpha1().HostRules("").List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
-			gslbutils.Errf("cluster: %s, msg: hostrule CRD not installed in the cluster, will skip", cluster.clusterName)
+			gslbutils.Errf("cluster: %s, msg: failed to fetch HostRule, will skip, error: %v",
+				cluster.clusterName, err)
 			return nil
 		}
 	} else {

--- a/gslb/ingestion/gslb.go
+++ b/gslb/ingestion/gslb.go
@@ -825,6 +825,11 @@ func InitializeMemberCluster(cfg *restclient.Config, cluster KubeClusterDetails,
 
 		aviCtrl = GetGSLBMemberController(cluster.clusterName, informerInstance, &hostRuleInformer)
 		aviCtrl.hrClientSet = hrClient
+		_, err := hrClient.AkoV1alpha1().HostRules("").List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			gslbutils.Errf("cluster: %s, msg: hostrule CRD not installed in the cluster, will skip", cluster.clusterName)
+			return nil
+		}
 	} else {
 		aviCtrl = GetGSLBMemberController(cluster.clusterName, informerInstance, nil)
 	}

--- a/gslb/rest/dq_nodes.go
+++ b/gslb/rest/dq_nodes.go
@@ -867,6 +867,8 @@ func (restOp *RestOperations) AviGSBuild(gsMeta *nodes.AviGSObjectGraph, restMet
 			}
 		}
 	} else if len(gsMeta.HmRefs) > 0 {
+		minHmUp := int32(len(gsMeta.HmRefs) + 1)
+		aviGslbSvc.Groups[0].MinHealthMonitorsUp = &minHmUp
 		// Add the custom health monitors here
 		aviGslbSvc.HealthMonitorRefs = []string{}
 		for _, hmName := range gsMeta.HmRefs {


### PR DESCRIPTION
If HostRule CRD is not installed in a member kubernetes/openshift
cluster, AMKO will skip the initialization of the member cluster and an
error will be logged.

This also fixes the number of minimum hm up for hm refs. This would
mean, if a user has specified custom health monitor refs, all the health
monitors have to be UP for a GSLB pool member to be up.