### PR TITLE
Add GDP invalid Health Monitor transition cases

### DIFF
--- a/gslb/test/integration/third_party_vips/int_lib.go
+++ b/gslb/test/integration/third_party_vips/int_lib.go
@@ -376,7 +376,7 @@ func verifyGSMembers(t *testing.T, expectedMembers []nodes.AviGSK8sObj, name, te
 	fetchedHmRefs := gs.HmRefs
 	sort.Strings(fetchedHmRefs)
 	if len(hmRefs) != len(fetchedHmRefs) {
-		t.Logf("length of hm refs don't match")
+		t.Logf("length of hm refs don't match, expected: %v, got: %v", hmRefs, fetchedHmRefs)
 		return false
 	}
 


### PR DESCRIPTION
Added a test case where initially a valid GDP object is added, then we
add a list of valid and invalid health monitor refs in the GDP object.
We verify that the members are unchanged and the GDP object was
rejected. We then fix the GDP object by removing the invalid health
monitor ref and adding a valid health monitor ref.

The invalid health monitor here means that the health monitor is not
federated which should be rejected by AMKO.