### PR TITLE
Fixes and integration tests for hostrules

### DIFF
--- a/gslb/ingestion/gslb_host_rule.go
+++ b/gslb/ingestion/gslb_host_rule.go
@@ -214,11 +214,6 @@ func AddGSLBHostRuleObj(obj interface{}, k8swq []workqueue.RateLimitingInterface
 		return
 	}
 
-	// GSLBHostRule for all other namespaces are rejected
-	if gslbhr.ObjectMeta.Namespace != gslbutils.AVISystem {
-		return
-	}
-
 	// Validate GSLBHostRule fields
 	gsFqdn := gslbhr.Spec.Fqdn
 	err := ValidateGSLBHostRule(gslbhr)
@@ -285,10 +280,7 @@ func handleGSLBHostRuleFQDNUpdate(oldGslbhr, newGslbhr *gslbhralphav1.GSLBHostRu
 func UpdateGSLBHostRuleObj(old, new interface{}, k8swq []workqueue.RateLimitingInterface, numWorkers uint32) {
 	oldGslbhr := old.(*gslbhralphav1.GSLBHostRule)
 	newGslbhr := new.(*gslbhralphav1.GSLBHostRule)
-	// GSLBHostRule for all other namespaces are rejected
-	if oldGslbhr.ObjectMeta.Namespace != gslbutils.AVISystem {
-		return
-	}
+
 	// Return if there's no change in the object
 	if oldGslbhr.ObjectMeta.ResourceVersion == newGslbhr.ObjectMeta.ResourceVersion {
 		return
@@ -335,9 +327,6 @@ func UpdateGSLBHostRuleObj(old, new interface{}, k8swq []workqueue.RateLimitingI
 func DeleteGSLBHostRuleObj(obj interface{}, k8swq []workqueue.RateLimitingInterface, numWorkers uint32) {
 	gslbhr := obj.(*gslbhralphav1.GSLBHostRule)
 
-	if gslbhr.Namespace != gslbutils.AVISystem {
-		return
-	}
 	// check if the GSLB Host Rule was previously rejected
 	if gslbhr.Status.Status == GslbHostRuleRejected {
 		return

--- a/gslb/ingestion/member_controllers.go
+++ b/gslb/ingestion/member_controllers.go
@@ -180,7 +180,7 @@ func DeleteFromLBSvcStore(clusterSvcStore *store.ClusterStore,
 }
 
 func isHostRuleAcceptable(hr *akov1alpha1.HostRule) bool {
-	if hr.Spec.VirtualHost.Gslb.Fqdn == "" || hr.Status.Status == gslbutils.HostRuleRejected ||
+	if hr.Spec.VirtualHost.Gslb.Fqdn == "" || hr.Status.Status != gslbutils.HostRuleAccepted ||
 		hr.Spec.VirtualHost.Fqdn == "" {
 		return false
 	}

--- a/gslb/test/integration/custom_fqdn/custom_fqdn_test.go
+++ b/gslb/test/integration/custom_fqdn/custom_fqdn_test.go
@@ -13,3 +13,368 @@
 */
 
 package custom_fqdn
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	routev1 "github.com/openshift/api/route/v1"
+
+	oshiftclient "github.com/openshift/client-go/route/clientset/versioned"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/gslbutils"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/ingestion"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/nodes"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/test/mockaviserver"
+	gslbalphav1 "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/apis/amko/v1alpha1"
+	gslbcs "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/client/v1alpha1/clientset/versioned"
+	gslbinformers "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/client/v1alpha1/informers/externalversions"
+	gdpcs "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/client/v1alpha2/clientset/versioned"
+	gdpinformers "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/client/v1alpha2/informers/externalversions"
+	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1alpha1"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+func TestMain(m *testing.M) {
+	setUp()
+	ret := m.Run()
+	cleanUp()
+	os.Exit(ret)
+}
+
+func cleanUp() {
+	for idx, testEnv := range testEnvs {
+		if testEnv != nil {
+			testEnv.Stop()
+			gslbutils.Logf("cluster %d stopped", idx)
+		}
+	}
+	// clear out the lists
+	cfgs = nil
+	clusterClients = nil
+	testEnvs = nil
+}
+
+func createRouteCRD() {
+	routeCRD = apiextensionv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "routes." + routev1.SchemeGroupVersion.Group,
+		},
+		Spec: apiextensionv1beta1.CustomResourceDefinitionSpec{
+			Group:   routev1.SchemeGroupVersion.Group,
+			Version: routev1.SchemeGroupVersion.Version,
+			Scope:   apiextensionv1beta1.NamespaceScoped,
+			Names: apiextensionv1beta1.CustomResourceDefinitionNames{
+				Plural: "routes",
+				Kind:   reflect.TypeOf(routev1.Route{}).Name(),
+			},
+		},
+	}
+}
+
+func createHostRuleCRD() {
+	hrCRD = apiextensionv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hostrules." + akov1alpha1.SchemeGroupVersion.Group,
+		},
+		Spec: apiextensionv1beta1.CustomResourceDefinitionSpec{
+			Group:   akov1alpha1.SchemeGroupVersion.Group,
+			Version: akov1alpha1.SchemeGroupVersion.Version,
+			Scope:   apiextensionv1beta1.NamespaceScoped,
+			Names: apiextensionv1beta1.CustomResourceDefinitionNames{
+				Plural: "hostrules",
+				Kind:   reflect.TypeOf(akov1alpha1.HostRule{}).Name(),
+			},
+		},
+	}
+}
+
+func SetUpEnvClusters() {
+	cfgs = make([]*rest.Config, MaxClusters)
+	clusterClients = make([]*kubernetes.Clientset, MaxClusters)
+	testEnvs = make([]*envtest.Environment, MaxClusters)
+	createHostRuleCRD()
+
+	testEnv1 := &envtest.Environment{
+		CRDDirectoryPaths: []string{AmkoCRDs},
+		CRDs: []client.Object{
+			&hrCRD,
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+	testEnvs[0] = testEnv1
+
+	createRouteCRD()
+	testEnv2 := &envtest.Environment{
+		CRDs: []client.Object{
+			&routeCRD,
+			&hrCRD,
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+	testEnvs[1] = testEnv2
+}
+
+func StartEnvClusters() {
+	var err error
+	for idx, testEnv := range testEnvs {
+		cfgs[idx], err = testEnv.Start()
+		if err != nil {
+			gslbutils.Errf("error occured while starting test env cluster %d: %v", idx, err)
+			CleanupAndExit()
+		}
+		gslbutils.Logf("started cluster %d", idx)
+		clientTransport := &http.Transport{}
+		cfgs[idx].Transport = clientTransport
+	}
+}
+
+func SetUpClients() {
+	for idx, cfg := range cfgs {
+		clientset, err := kubernetes.NewForConfig(cfg)
+		if err != nil {
+			gslbutils.Errf("error occured while fetching clientset for cluster %d: %v", idx, err)
+			CleanupAndExit()
+		}
+		gslbutils.Logf("set up the clientset for cluster %d", idx)
+		clusterClients[idx] = clientset
+	}
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: AviSystemNS,
+		},
+	}
+	clusterClients[ConfigCluster].CoreV1().Namespaces().Create(context.TODO(), &ns, metav1.CreateOptions{})
+	oc, err := oshiftclient.NewForConfig(cfgs[Oshift])
+	if err != nil {
+		gslbutils.Errf("error occured while fetching the openshift client: %v", err)
+		CleanupAndExit()
+	}
+	oshiftClient = oc
+}
+
+func SyncFromTestIngestionLayer(key string, wg *sync.WaitGroup) error {
+	gslbutils.Logf("recieved key from ingestion layer: %s", key)
+	ingestionKeyChan <- key
+
+	return nil
+}
+
+func SyncFromTestNodesLayer(key string, wg *sync.WaitGroup) error {
+	gslbutils.Logf("recived key from graph layer: %s", key)
+	graphKeyChan <- key
+
+	return nil
+}
+
+func SetUpTestWorkerQueues() {
+	gslbutils.SetWaitGroupMap()
+	numIngestionWorkers := utils.NumWorkersIngestion
+	ingestionQueueParams := utils.WorkerQueue{NumWorkers: numIngestionWorkers, WorkqueueName: utils.ObjectIngestionLayer}
+	graphQueueParams := utils.WorkerQueue{NumWorkers: gslbutils.NumRestWorkers, WorkqueueName: utils.GraphLayer}
+
+	utils.SharedWorkQueue(&ingestionQueueParams, &graphQueueParams)
+
+	ingestionSharedQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
+	ingestionSharedQueue.SyncFunc = nodes.SyncFromIngestionLayer
+	ingestionSharedQueue.Run(stopCh, gslbutils.GetWaitGroupFromMap(gslbutils.WGIngestion))
+
+	// Set workers for layer 3 (REST layer)
+	graphSharedQueue := utils.SharedWorkQueue().GetQueueByName(utils.GraphLayer)
+	graphSharedQueue.SyncFunc = SyncFromTestNodesLayer
+	graphSharedQueue.Run(stopCh, gslbutils.GetWaitGroupFromMap(gslbutils.WGGraph))
+}
+
+func SetUpAMKOConfigs() {
+	gslbutils.SetTestMode(true)
+	os.Setenv("MOCK_DATA_DIR", "../../avimockobjects/")
+	os.Setenv("GSLB_CONFIG", "test-data")
+
+	gslbutils.GlobalKubeClient = clusterClients[ConfigCluster]
+	gslbClient, err := gslbcs.NewForConfig(cfgs[ConfigCluster])
+	if err != nil {
+		gslbutils.Errf("error occured while creating a clientset for gslb: %v", err)
+		CleanupAndExit()
+	}
+	gslbutils.GlobalGslbClient = gslbClient
+	gdpClient, err := gdpcs.NewForConfig(cfgs[ConfigCluster])
+	if err != nil {
+		gslbutils.Errf("error occured while creating a clientset for gdp: %v", err)
+		CleanupAndExit()
+	}
+	gslbutils.GlobalGdpClient = gdpClient
+
+	gslbutils.PublishGDPStatus = true
+	gslbutils.PublishGSLBStatus = true
+	stopCh = utils.SetupSignalHandler()
+
+	SetUpTestWorkerQueues()
+	ingestion.SetInformerListTimeout(120)
+	gslbInformerFactory := gslbinformers.NewSharedInformerFactory(gslbClient, time.Second*30)
+
+	gslbController := ingestion.GetNewController(clusterClients[ConfigCluster], gslbClient,
+		gslbInformerFactory, ingestion.AddGSLBConfigObject, GetTestEnvClustersAsGslbMembers)
+	gslbInformer := gslbInformerFactory.Amko().V1alpha1().GSLBConfigs()
+	go gslbInformer.Informer().Run(stopCh)
+
+	gdpInformerFactory := gdpinformers.NewSharedInformerFactory(gdpClient, time.Second*30)
+	gdpCtrl := ingestion.InitializeGDPController(clusterClients[ConfigCluster], gdpClient, gdpInformerFactory,
+		ingestion.AddGDPObj, ingestion.UpdateGDPObj, ingestion.DeleteGDPObj)
+	gdpInformer := gdpInformerFactory.Amko().V1alpha2().GlobalDeploymentPolicies()
+	go gdpInformer.Informer().Run(stopCh)
+
+	gslbhrCtrl := ingestion.InitializeGSLBHostRuleController(clusterClients[ConfigCluster],
+		gslbClient, gslbInformerFactory, ingestion.AddGSLBHostRuleObj,
+		ingestion.UpdateGSLBHostRuleObj, ingestion.DeleteGSLBHostRuleObj)
+
+	gslbhrInformer := gslbInformerFactory.Amko().V1alpha1().GSLBHostRules()
+	go gslbhrInformer.Informer().Run(stopCh)
+
+	go ingestion.RunControllers(gslbController, gdpCtrl, gslbhrCtrl, stopCh)
+}
+
+func GetTestEnvClustersAsGslbMembers(arg1 string, arg2 []gslbalphav1.MemberCluster) ([]*ingestion.GSLBMemberController, error) {
+	clients := make(map[string]*kubernetes.Clientset)
+
+	testClustersContexts := []ingestion.KubeClusterDetails{
+		ingestion.GetNewKubeClusterDetails(K8sContext, "", "", nil),
+		ingestion.GetNewKubeClusterDetails(OshiftContext, "", "", nil),
+	}
+
+	memberClusterList := make([]*ingestion.GSLBMemberController, 0)
+	for idx, c := range testClustersContexts {
+		member := ingestion.InitializeMemberCluster(cfgs[idx], c, clients)
+		gslbutils.Logf("test cluster: %s, informers set up", c.GetClusterContextName())
+		memberClusterList = append(memberClusterList, member)
+	}
+	return memberClusterList, nil
+}
+
+func CleanupAndExit() {
+	cleanUp()
+	os.Exit(1)
+}
+
+func SetUpMockController() {
+	mockaviserver.NewAviMockAPIServer()
+	apiURL = mockaviserver.GetMockServerURL()
+	gslbutils.Logf("test controller started, URL: %s", apiURL)
+}
+
+func CreateAviSecretInConfigCluster() {
+	secretObj := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      AviSecret,
+			Namespace: AviSystemNS,
+		},
+		Data: map[string][]byte{
+			"username": []byte("admin"),
+			"password": []byte("admin"),
+		},
+	}
+	_, err := clusterClients[ConfigCluster].CoreV1().Secrets(AviSystemNS).Create(context.TODO(), &secretObj, metav1.CreateOptions{})
+	if err != nil {
+		gslbutils.Errf("error in creating a secret: %v", err)
+		CleanupAndExit()
+	}
+	gslbutils.Logf("created test secret object")
+}
+
+func setUp() {
+	// Set the location of the api server and etcd binaries
+	KubeBuilderAssetsVal = os.Getenv(KubeBuilderAssetsEnv)
+	if KubeBuilderAssetsVal == "" {
+		panic("kube builder assets directory not set, set the environment variable KUBEBUILDER_ASSETS and re-run")
+	}
+
+	ingestionKeyChan = make(chan string)
+	graphKeyChan = make(chan string)
+
+	// Set up the clusters
+	SetUpEnvClusters()
+	// Start the clusters
+	StartEnvClusters()
+	// Fetch the kube clients for all clusters
+	SetUpClients()
+
+	// Inialize AMKO configs
+	SetUpAMKOConfigs()
+
+	// Set up mock AVI controller API server
+	SetUpMockController()
+
+	// Create AVI secret
+	CreateAviSecretInConfigCluster()
+
+	// Setup Gslb Config object
+	AddTestGslbConfigObject()
+}
+
+type forGomega struct {
+}
+
+func (f forGomega) Fatalf(format string, args ...interface{}) {
+	gslbutils.Errf(format, args...)
+	CleanupAndExit()
+}
+
+func GetTestGSLBConfigObject() *gslbalphav1.GSLBConfig {
+	return &gslbalphav1.GSLBConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      GslbConfigName,
+			Namespace: AviSystemNS,
+		},
+
+		Spec: gslbalphav1.GSLBConfigSpec{
+			GSLBLeader: gslbalphav1.GSLBLeader{
+				Credentials:       AviSecret,
+				ControllerVersion: "20.1.4",
+				ControllerIP:      apiURL,
+			},
+			MemberClusters: []gslbalphav1.MemberCluster{
+				{ClusterContext: K8sContext},
+				{ClusterContext: OshiftContext},
+			},
+			RefreshInterval:     100,
+			LogLevel:            "DEBUG",
+			UseCustomGlobalFqdn: true,
+		},
+	}
+}
+
+func AddTestGslbConfigObject() {
+	var f forGomega
+	gcClient := gslbutils.GlobalGslbClient
+
+	t := types.GomegaTestingT(f)
+	g := gomega.NewGomegaWithT(t)
+	gc := GetTestGSLBConfigObject()
+	_, err := gcClient.AmkoV1alpha1().GSLBConfigs(AviSystemNS).Create(context.TODO(), gc,
+		metav1.CreateOptions{})
+	if err != nil {
+		gslbutils.Errf("error in creating GSLBConfig object: %v", err)
+		return
+	}
+	g.Eventually(func() string {
+		gcObj, err := gcClient.AmkoV1alpha1().GSLBConfigs(AviSystemNS).Get(context.TODO(), GslbConfigName,
+			metav1.GetOptions{})
+		if err != nil {
+			gslbutils.Errf("failed to fetch GSLBConfig object: %v", err)
+			return ""
+		}
+		return gcObj.Status.State
+	}).Should(gomega.Equal("success: gslb config accepted"))
+}

--- a/gslb/test/integration/custom_fqdn/hostrule_test.go
+++ b/gslb/test/integration/custom_fqdn/hostrule_test.go
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package custom_fqdn
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/gslbutils"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/nodes"
+	ingestion_test "github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/test/ingestion"
+	gdpalphav2 "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/apis/amko/v1alpha2"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	routeCluster = "oshift"
+	ingCluster   = "k8s"
+)
+
+func getTestGDP(t *testing.T, name, ns string) *gdpalphav2.GlobalDeploymentPolicy {
+	gdp, err := gslbutils.GlobalGdpClient.AmkoV1alpha2().GlobalDeploymentPolicies(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get GDP object %s: %v", name, err)
+	}
+	return gdp
+}
+
+func updateTestGDP(t *testing.T, gdp *gdpalphav2.GlobalDeploymentPolicy) *gdpalphav2.GlobalDeploymentPolicy {
+	newGdp, err := gslbutils.GlobalGdpClient.AmkoV1alpha2().GlobalDeploymentPolicies(gdp.Namespace).Update(context.TODO(), gdp, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("update on GDP %v failed with %v", gdp, err)
+	}
+	VerifyGDPStatus(t, gdp.Namespace, gdp.Name, "success")
+	return newGdp
+}
+
+func addIngressAndRouteObjects(t *testing.T, testPrefix string) (*networkingv1beta1.Ingress, *routev1.Route) {
+	ingName := testPrefix + "def-ing"
+	routeName := testPrefix + "def-route"
+	ns := "default"
+	host := testPrefix + ingestion_test.TestDomain1
+	ingIPAddr := "10.10.100.1"
+	routeIPAddr := "10.10.200.1"
+	ingHostIPMap := map[string]string{host: ingIPAddr}
+
+	t.Cleanup(func() {
+		k8sDeleteIngress(t, clusterClients[K8s], ingName, ns)
+		oshiftDeleteRoute(t, clusterClients[Oshift], routeName, ns)
+	})
+
+	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
+		ingHostIPMap, true)
+	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
+		routeCluster, host, routeIPAddr, true)
+	return ingObj, routeObj
+}
+
+func addTestGDPWithProperties(t *testing.T, hmRefs []string, ttl *int, sitePersistence *string) *gdpalphav2.GlobalDeploymentPolicy {
+	gdpObj := GetTestDefaultGDPObject()
+	gdpObj.Spec.MatchRules.AppSelector = gdpalphav2.AppSelector{
+		Label: appLabel,
+	}
+	gdpObj.Spec.MatchClusters = []gdpalphav2.ClusterProperty{
+		{Cluster: K8sContext}, {Cluster: OshiftContext},
+	}
+	gdpObj.Spec.HealthMonitorRefs = hmRefs
+	gdpObj.Spec.TTL = ttl
+	gdpObj.Spec.SitePersistenceRef = sitePersistence
+
+	newGDP, err := AddAndVerifyTestGDPSuccess(t, gdpObj)
+	if err != nil {
+		t.Fatalf("error in creating and verifying GDP object %v: %v", newGDP, err)
+	}
+
+	t.Cleanup(func() {
+		DeleteTestGDP(t, gdpObj.Namespace, gdpObj.Name)
+	})
+
+	return newGDP
+}
+
+// Add ingress and route objects, create a GDP object, create host rules and verify
+func TestHostRuleCreate(t *testing.T) {
+	testPrefix := "hr-"
+	hmRefs := []string{"my-hm1"}
+	hrNameK8s := testPrefix + "hr"
+	hrNameOC := testPrefix + "hr"
+	gfqdn := "test-gs.avi.com"
+
+	addTestGDPWithProperties(t, hmRefs, nil, nil)
+	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
+
+	var expectedMembers []nodes.AviGSK8sObj
+	g := gomega.NewGomegaWithT(t)
+
+	// create a host rule for the ingress object's hostname, verify GS member
+	k8sHr := getDefaultHostRule(hrNameK8s, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+		gslbutils.HostRuleAccepted)
+	createHostRule(t, K8s, k8sHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// create a host rule for the route object's hostname, verify GS members
+	ocHr := getDefaultHostRule(hrNameOC, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+		gslbutils.HostRuleAccepted)
+	createHostRule(t, Oshift, ocHr)
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Add ingress and route objects, create a GDP object, create invalid host rules, update them to
+// valid state
+func TestHostRuleInvalidToValid(t *testing.T) {
+	testPrefix := "hriv-"
+	hmRefs := []string{"my-hm1"}
+	hrNameK8s := testPrefix + "hr"
+	hrNameOC := testPrefix + "hr"
+	gfqdn := "test-gs.avi.com"
+
+	addTestGDPWithProperties(t, hmRefs, nil, nil)
+	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
+
+	var expectedMembers []nodes.AviGSK8sObj
+	g := gomega.NewGomegaWithT(t)
+
+	// create a invalid host rule for the ingress object's hostname, verify GS member
+	k8sHr := getDefaultHostRule(hrNameK8s, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+		gslbutils.HostRuleRejected)
+	createHostRule(t, K8s, k8sHr)
+
+	// create a host rule for the route object's hostname, verify GS members
+	ocHr := getDefaultHostRule(hrNameOC, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+		gslbutils.HostRuleAccepted)
+	createHostRule(t, Oshift, ocHr)
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// update the hostrule to a valid one for the ingress object
+	newK8sHr := getTestHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	newK8sHr.Status.Status = gslbutils.HostRuleAccepted
+	updateHostRule(t, K8s, newK8sHr)
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Add ingress and route objects, create a GDP object, create valid host rules and update them to
+// invalid
+func TestHostRuleValidToInvalid(t *testing.T) {
+	testPrefix := "hrvi-"
+	hmRefs := []string{"my-hm1"}
+	hrNameK8s := testPrefix + "hr"
+	hrNameOC := testPrefix + "hr"
+	gfqdn := "test-gs.avi.com"
+
+	addTestGDPWithProperties(t, hmRefs, nil, nil)
+	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
+
+	var expectedMembers []nodes.AviGSK8sObj
+	g := gomega.NewGomegaWithT(t)
+
+	// create a host rule for the ingress object's hostname, verify GS member
+	k8sHr := getDefaultHostRule(hrNameK8s, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+		gslbutils.HostRuleAccepted)
+	createHostRule(t, K8s, k8sHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// create a host rule for the route object's hostname, verify GS members
+	ocHr := getDefaultHostRule(hrNameOC, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+		gslbutils.HostRuleAccepted)
+	createHostRule(t, Oshift, ocHr)
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// change the ingress's host rule to invalid
+	newK8sHr := getTestHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	newK8sHr.Status.Status = gslbutils.HostRuleRejected
+	updateHostRule(t, K8s, newK8sHr)
+
+	// GS graph should now have only one member
+	expectedMembers = []nodes.AviGSK8sObj{getTestGSMemberFromRoute(t, routeObj, routeCluster, 1)}
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Add an ingress object, create a GDP object, create multiple host rules, one accepted and other
+// rejected
+func TestHostRuleMultiple(t *testing.T) {
+	testPrefix := "hr-"
+	hmRefs := []string{"my-hm1"}
+	hrNameK8s1 := testPrefix + "hr1"
+	hrNameK8s2 := testPrefix + "hr2"
+	gfqdn1 := "test-gs.avi.com"
+	gfqdn2 := "test-gs2.avi.com"
+
+	addTestGDPWithProperties(t, hmRefs, nil, nil)
+	ingObj, _ := addIngressAndRouteObjects(t, testPrefix)
+
+	var expectedMembers []nodes.AviGSK8sObj
+	g := gomega.NewGomegaWithT(t)
+
+	// create a host rule for the ingress object's hostname, verify GS member
+	k8sHr := getDefaultHostRule(hrNameK8s1, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn1,
+		gslbutils.HostRuleAccepted)
+	createHostRule(t, K8s, k8sHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn1, utils.ADMIN_NS, hmRefs, nil, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	newK8sHr := getDefaultHostRule(hrNameK8s2, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn2,
+		gslbutils.HostRuleRejected)
+	createHostRule(t, K8s, newK8sHr)
+
+	// there shouldn't be any change in the GS graph
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn1, utils.ADMIN_NS, hmRefs, nil, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}

--- a/gslb/test/integration/custom_fqdn/lib.go
+++ b/gslb/test/integration/custom_fqdn/lib.go
@@ -1,0 +1,688 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package custom_fqdn
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
+	oshiftclient "github.com/openshift/client-go/route/clientset/versioned"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/gslbutils"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/k8sobjects"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/nodes"
+	ingestion_test "github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/test/ingestion"
+	gslbalphav1 "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/apis/amko/v1alpha1"
+	gdpalphav2 "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/apis/amko/v1alpha2"
+	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1alpha1"
+	hrcs "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1alpha1/clientset/versioned"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	apiextensionv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+const (
+	KubeBuilderAssetsEnv = "KUBEBUILDER_ASSETS"
+	// list indices for k8s cluster, openshift cluster and config cluster (where AMKO is running)
+	// Config cluster and K8s cluster are same here
+	K8s           = 0
+	ConfigCluster = 0
+	Oshift        = 1
+	MaxClusters   = 2
+	// AMKO CRD directory
+	AmkoCRDs = "../../../../helm/amko/crds"
+
+	AviSystemNS    = "avi-system"
+	AviSecret      = "avi-secret"
+	GslbConfigName = "test-gc"
+	GDPName        = "test-gdp"
+	K8sContext     = "k8s"
+	OshiftContext  = "oshift"
+)
+
+var (
+	cfgs                 []*rest.Config
+	clusterClients       []*kubernetes.Clientset
+	testEnvs             []*envtest.Environment
+	stopCh               <-chan struct{}
+	apiURL               string
+	ingestionKeyChan     chan string
+	graphKeyChan         chan string
+	oshiftClient         *oshiftclient.Clientset
+	KubeBuilderAssetsVal string
+	routeCRD             apiextensionv1beta1.CustomResourceDefinition
+	hrCRD                apiextensionv1beta1.CustomResourceDefinition
+)
+
+var appLabel map[string]string = map[string]string{"key": "value"}
+
+func BuildIngressObj(name, ns, svc, cname string, hostIPs map[string]string, withStatus bool, secretName string) *networkingv1beta1.Ingress {
+	ingObj := &networkingv1beta1.Ingress{}
+	ingObj.Namespace = ns
+	ingObj.Name = name
+
+	var hosts []string
+	for ingHost, ingIP := range hostIPs {
+		hosts = append(hosts, ingHost)
+		ingObj.Spec.Rules = append(ingObj.Spec.Rules, networkingv1beta1.IngressRule{
+			Host: ingHost,
+		})
+		if !withStatus {
+			continue
+		}
+		ingObj.Status.LoadBalancer.Ingress = append(ingObj.Status.LoadBalancer.Ingress, corev1.LoadBalancerIngress{
+			IP:       ingIP,
+			Hostname: ingHost,
+		})
+	}
+	labelMap := make(map[string]string)
+	labelMap["key"] = "value"
+	ingObj.Labels = labelMap
+	if secretName != "" {
+		if len(ingObj.Spec.TLS) == 0 {
+			ingObj.Spec.TLS = make([]networkingv1beta1.IngressTLS, 0)
+		}
+		ingObj.Spec.TLS = append(ingObj.Spec.TLS, networkingv1beta1.IngressTLS{
+			Hosts:      hosts,
+			SecretName: secretName,
+		})
+	}
+
+	return ingObj
+}
+
+func BuildRouteObj(name, ns, svc, cname, host, ip string, withStatus bool) *routev1.Route {
+	routeObj := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+		Spec: routev1.RouteSpec{
+			Host: host,
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: svc,
+			},
+		},
+	}
+
+	if withStatus {
+		routeObj.Status = routev1.RouteStatus{
+			Ingress: []routev1.RouteIngress{
+				{
+					Conditions: []routev1.RouteIngressCondition{
+						{
+							Message: ip,
+						},
+					},
+					RouterName: "ako-test",
+					Host:       host,
+				},
+			},
+		}
+	}
+
+	labelMap := make(map[string]string)
+	labelMap["key"] = "value"
+	routeObj.Labels = labelMap
+
+	return routeObj
+}
+
+func getAnnotations(hostNames []string) map[string]string {
+	annot := map[string]string{
+		"ako.vmware.com/controller-cluster-uuid": "cluster-XXXXX",
+		"ako.vmware.com/host-fqdn-vs-uuid-map":   "",
+	}
+
+	hostVS := map[string]string{}
+	for _, host := range hostNames {
+		hostVS[host] = "virtualservice-" + host
+	}
+	jsonData, _ := json.Marshal(hostVS)
+	annot["ako.vmware.com/host-fqdn-vs-uuid-map"] = string(jsonData)
+	return annot
+}
+
+func buildk8sSecret(ns string) *corev1.Secret {
+	secretObj := corev1.Secret{}
+	secretObj.Name = "test-secret"
+	secretObj.Namespace = ns
+	secretObj.Data = make(map[string][]byte)
+	secretObj.Data["tls.crt"] = []byte("")
+	secretObj.Data["tls.key"] = []byte("")
+	return &secretObj
+}
+
+func deletek8sSecret(t *testing.T, kc *kubernetes.Clientset, ns, name string) {
+	err := kc.CoreV1().Secrets(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		t.Fatalf("error in deleting secret object %s/%s: %v", ns, name, err)
+	}
+	t.Logf("deleted secret object %s/%s", ns, name)
+}
+
+func k8sAddIngress(t *testing.T, kc *kubernetes.Clientset, name, ns, svc, cname string,
+	hostIPs map[string]string, tls bool) *networkingv1beta1.Ingress {
+
+	secreName := "test-secret"
+	if tls {
+		secretObj := buildk8sSecret(ns)
+		_, err := kc.CoreV1().Secrets(ns).Create(context.TODO(), secretObj, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("error in creating secret object %v: %v", secretObj, err)
+		}
+		t.Cleanup(func() {
+			deletek8sSecret(t, kc, secretObj.Namespace, secretObj.Name)
+		})
+	}
+	var ingObj *networkingv1beta1.Ingress
+	if tls {
+		ingObj = BuildIngressObj(name, ns, svc, cname, hostIPs, true, secreName)
+	} else {
+		ingObj = BuildIngressObj(name, ns, svc, cname, hostIPs, true, "")
+	}
+	t.Logf("built an ingress object with name: %s, ns: %s, cname: %s", ns, name, cname)
+	var hostnames []string
+	for _, r := range ingObj.Spec.Rules {
+		hostnames = append(hostnames, r.Host)
+	}
+	ingObj.Annotations = getAnnotations(hostnames)
+	_, err := kc.NetworkingV1beta1().Ingresses(ns).Create(context.TODO(), ingObj, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in creating ingress: %v", err)
+	}
+	patchPayload, _ := json.Marshal(map[string]interface{}{
+		"status": ingObj.Status,
+	})
+
+	_, err = kc.NetworkingV1beta1().Ingresses(ns).Patch(context.TODO(), name, types.MergePatchType, patchPayload, metav1.PatchOptions{}, "status")
+	if err != nil {
+		t.Fatalf("error in patching ingress: %v", err)
+	}
+	t.Logf("ingress object successfully created with name: %s, ns: %s, cname: %s", ns, name, cname)
+	return ingObj
+}
+
+func oshiftAddRoute(t *testing.T, kc *kubernetes.Clientset, name, ns, svc, cname, host,
+	ip string, tls bool) *routev1.Route {
+	routeObj := BuildRouteObj(name, ns, svc, cname, host, ip, true)
+	if tls {
+		routeObj.Spec.TLS = &routev1.TLSConfig{
+			Termination:   routev1.TLSTerminationEdge,
+			Certificate:   "cert",
+			Key:           "key",
+			CACertificate: "ca-cert",
+		}
+	}
+	t.Logf("built a route object with name: %s, ns: %s and cname: %s", name, ns, cname)
+	// applying annotations
+	hostname := routeObj.Spec.Host
+	routeObj.Annotations = getAnnotations([]string{hostname})
+	newObj, err := oshiftClient.RouteV1().Routes(ns).Create(context.TODO(), routeObj, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't create route obj: %v, err: %v", routeObj, err)
+	}
+	t.Logf("route object successfully created with name: %s, ns: %s, cname: %s", ns, name, cname)
+	return newObj
+}
+
+func k8sDeleteIngress(t *testing.T, kc *kubernetes.Clientset, name string, ns string) {
+	err := kc.NetworkingV1beta1().Ingresses(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("error in creating ingress: %v", err)
+	}
+}
+
+func oshiftDeleteRoute(t *testing.T, kc *kubernetes.Clientset, name string, ns string) {
+	err := oshiftClient.RouteV1().Routes(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't delete route obj: %v, err: %v", name, err)
+	}
+}
+
+func BuildAddAndVerifyAppSelectorTestGDP(t *testing.T) (*gdpalphav2.GlobalDeploymentPolicy, error) {
+	gdpObj := GetTestDefaultGDPObject()
+	gdpObj.Spec.MatchRules.AppSelector = gdpalphav2.AppSelector{
+		Label: appLabel,
+	}
+	gdpObj.Spec.MatchClusters = []gdpalphav2.ClusterProperty{
+		{Cluster: K8sContext}, {Cluster: OshiftContext},
+	}
+	return AddAndVerifyTestGDPSuccess(t, gdpObj)
+}
+
+func BuildIngressKeyAndVerify(t *testing.T, timeoutExpected bool, op, cname, ns, name, hostname string) {
+	expectedKey := ingestion_test.GetIngressKey(op, cname, ns, name, hostname)
+	t.Logf("key: %s, msg: will verify key", expectedKey)
+	passed, errStr := ingestion_test.WaitAndVerify(t, []string{expectedKey}, timeoutExpected, ingestionKeyChan)
+	if !passed {
+		t.Fatalf(errStr)
+	}
+}
+
+func BuildRouteKeyAndVerify(t *testing.T, timeoutExpected bool, op, cname, ns, name string) {
+	expectedKey := ingestion_test.GetRouteKey(op, cname, ns, name)
+	t.Logf("key: %s, msg: will verify key", expectedKey)
+	passed, errStr := ingestion_test.WaitAndVerify(t, []string{expectedKey}, timeoutExpected, ingestionKeyChan)
+	if !passed {
+		t.Fatalf(errStr)
+	}
+}
+
+func GetTestDefaultGDPObject() *gdpalphav2.GlobalDeploymentPolicy {
+	matchRules := gdpalphav2.MatchRules{}
+	matchClusters := []gdpalphav2.ClusterProperty{}
+	return &gdpalphav2.GlobalDeploymentPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: AviSystemNS,
+			Name:      GDPName,
+		},
+		Spec: gdpalphav2.GDPSpec{
+			MatchRules:    matchRules,
+			MatchClusters: matchClusters,
+		},
+	}
+}
+
+func AddTestGDP(t *testing.T, gdp *gdpalphav2.GlobalDeploymentPolicy) (*gdpalphav2.GlobalDeploymentPolicy, error) {
+	newGdpObj, err := gslbutils.GlobalGdpClient.AmkoV1alpha2().GlobalDeploymentPolicies(gdp.Namespace).Create(context.TODO(),
+		gdp, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	t.Logf("created new GDP object %s in %s namespace", newGdpObj.Name, newGdpObj.Namespace)
+	return newGdpObj, nil
+}
+
+func VerifyGDPStatus(t *testing.T, ns, name, status string) {
+	g := gomega.NewGomegaWithT(t)
+	g.Eventually(func() string {
+		gdpObj, err := gslbutils.GlobalGdpClient.AmkoV1alpha2().GlobalDeploymentPolicies(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to fetch GDP object: %v", err)
+			return ""
+		}
+		return gdpObj.Status.ErrorStatus
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(status), "GDP status must be equal to %s", status)
+}
+
+func AddAndVerifyTestGDPSuccess(t *testing.T, gdp *gdpalphav2.GlobalDeploymentPolicy) (*gdpalphav2.GlobalDeploymentPolicy, error) {
+	newGdpObj, err := AddTestGDP(t, gdp)
+	if err != nil {
+		return nil, err
+	}
+	VerifyGDPStatus(t, newGdpObj.Namespace, newGdpObj.Name, "success")
+	return newGdpObj, nil
+}
+
+func AddAndVerifyTestGDPFailure(t *testing.T, gdp *gdpalphav2.GlobalDeploymentPolicy, status string) (*gdpalphav2.GlobalDeploymentPolicy, error) {
+	newGdpObj, err := AddTestGDP(t, gdp)
+	if err != nil {
+		return nil, err
+	}
+	VerifyGDPStatus(t, newGdpObj.Namespace, newGdpObj.Name, status)
+	return newGdpObj, nil
+}
+
+func GetTestGSGraphFromName(t *testing.T, gsName string) *nodes.AviGSObjectGraph {
+	gsList := nodes.SharedAviGSGraphLister()
+	key := utils.ADMIN_NS + "/" + gsName
+	found, gsObj := gsList.Get(key)
+	if !found {
+		t.Logf("error in fetching GS for key %s", key)
+		return nil
+	}
+	gsGraph := gsObj.(*nodes.AviGSObjectGraph)
+	return gsGraph.GetCopy()
+}
+
+func verifyGSMembers(t *testing.T, expectedMembers []nodes.AviGSK8sObj, name, tenant string,
+	hmRefs []string, sitePersistenceRef *string, ttl *int) bool {
+
+	gs := GetTestGSGraphFromName(t, name)
+	if gs == nil {
+		t.Logf("GS Graph is nil, this is unexpected")
+		return false
+	}
+	members := gs.MemberObjs
+	if len(members) != len(expectedMembers) {
+		t.Logf("length of members don't match")
+		return false
+	}
+
+	sort.Strings(hmRefs)
+	fetchedHmRefs := gs.HmRefs
+	sort.Strings(fetchedHmRefs)
+	if len(hmRefs) != len(fetchedHmRefs) {
+		t.Logf("length of hm refs don't match")
+		return false
+	}
+
+	if len(hmRefs) != 0 {
+		for idx, h := range hmRefs {
+			if h != fetchedHmRefs[idx] {
+				t.Logf("hm ref didn't match, expected list: %v, fetched list: %v", hmRefs, fetchedHmRefs)
+				return false
+			}
+		}
+	}
+
+	if sitePersistenceRef != nil {
+		if gs.SitePersistenceRef == nil {
+			t.Logf("Site persistence ref should not be nil, expected value: %s", *sitePersistenceRef)
+			return false
+		}
+		if *sitePersistenceRef != *gs.SitePersistenceRef {
+			t.Logf("Site persistence should be %s, it is %s", *sitePersistenceRef, *gs.SitePersistenceRef)
+			return false
+		}
+	} else {
+		if gs.SitePersistenceRef != nil {
+			t.Logf("Site persistence ref should be nil, it is %s", *gs.SitePersistenceRef)
+			return false
+		}
+	}
+
+	if ttl != nil {
+		if gs.TTL == nil {
+			t.Logf("TTL should not be nil")
+			return false
+		}
+		if *gs.TTL != *ttl {
+			t.Logf("TTL values should be equal, expected: %d, fetched: %d", *ttl, *gs.TTL)
+			return false
+		}
+	} else {
+		if gs.TTL != nil {
+			t.Logf("TTL value should be nil, it is %d", *gs.TTL)
+			return false
+		}
+	}
+
+	for _, e := range expectedMembers {
+		for _, m := range members {
+			if e.Cluster != m.Cluster || e.Namespace != m.Namespace || e.Name != m.Name {
+				continue
+			}
+			if e.IPAddr != m.IPAddr {
+				t.Logf("IP address don't match, expected: %s, fetched: %s", e.IPAddr, m.IPAddr)
+				return false
+			}
+			if e.ControllerUUID != m.ControllerUUID {
+				t.Logf("Controller UUIDs don't match for member, expected: %s, fetched: %s", e.ControllerUUID,
+					m.ControllerUUID)
+				return false
+			}
+			if e.IsPassthrough != m.IsPassthrough {
+				t.Logf("IsPassthrough don't match for member, expected: %v, fetched: %v", e.IsPassthrough,
+					m.IsPassthrough)
+				return false
+			}
+			if e.Weight != m.Weight {
+				t.Logf("Weight for members don't match, expected: %d, fetched: %d", e.Weight, m.Weight)
+				return false
+			}
+			if e.TLS != m.TLS {
+				t.Logf("TLS for members don't match, expected: %v, fetched: %v", e.TLS, m.TLS)
+				return false
+			}
+			if e.VirtualServiceUUID != m.VirtualServiceUUID {
+				t.Logf("VS UUIDs should match, expected: %v, fetched: %v", e.VirtualServiceUUID,
+					m.VirtualServiceUUID)
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func getTestGSMemberFromIng(t *testing.T, ingObj *networkingv1beta1.Ingress, cname string,
+	weight int32) nodes.AviGSK8sObj {
+	vsUUIDs := make(map[string]string)
+	if err := json.Unmarshal([]byte(ingObj.Annotations[k8sobjects.VSAnnotation]), &vsUUIDs); err != nil {
+		t.Fatalf("error in getting annotations from ingress object %v: %v", ingObj.Annotations, err)
+	}
+	hostName := ingObj.Spec.Rules[0].Host
+	var tls bool
+	if len(ingObj.Spec.TLS) != 0 {
+		tls = true
+	}
+
+	paths := []string{}
+	for _, rule := range ingObj.Spec.Rules {
+		if rule.Host == hostName {
+			if rule.HTTP == nil || rule.HTTP.Paths == nil || len(rule.HTTP.Paths) == 0 {
+				paths = append(paths, "/")
+				continue
+			}
+			for _, p := range rule.HTTP.Paths {
+				paths = append(paths, p.Path)
+			}
+		}
+	}
+	return getTestGSMember(cname, gslbutils.IngressType, ingObj.Name, ingObj.Namespace,
+		ingObj.Status.LoadBalancer.Ingress[0].IP, vsUUIDs[hostName],
+		ingObj.Annotations[k8sobjects.ControllerAnnotation],
+		true, false, tls, paths, weight)
+}
+
+func getTestGSMemberFromRoute(t *testing.T, routeObj *routev1.Route, cname string,
+	weight int32) nodes.AviGSK8sObj {
+	vsUUIDs := make(map[string]string)
+	if err := json.Unmarshal([]byte(routeObj.Annotations[k8sobjects.VSAnnotation]), &vsUUIDs); err != nil {
+		t.Fatalf("error in getting annotations from ingress object %v: %v", routeObj.Annotations, err)
+	}
+	hostName := routeObj.Spec.Host
+	var tls bool
+	if routeObj.Spec.TLS != nil {
+		tls = true
+	}
+	paths := []string{routeObj.Spec.Path}
+
+	return getTestGSMember(cname, gslbutils.RouteType, routeObj.Name, routeObj.Namespace,
+		routeObj.Status.Ingress[0].Conditions[0].Message, vsUUIDs[hostName],
+		routeObj.Annotations[k8sobjects.ControllerAnnotation],
+		true, false, tls, paths, weight)
+}
+
+func getTestGSMember(cname, objType, name, ns, ipAddr, vsUUID, controllerUUID string,
+	syncVIPOnly, isPassthrough, tls bool, paths []string, weight int32) nodes.AviGSK8sObj {
+	return nodes.AviGSK8sObj{
+		Cluster:            cname,
+		ObjType:            objType,
+		Name:               name,
+		Namespace:          ns,
+		IPAddr:             ipAddr,
+		VirtualServiceUUID: vsUUID,
+		ControllerUUID:     controllerUUID,
+		SyncVIPOnly:        syncVIPOnly,
+		IsPassthrough:      isPassthrough,
+		TLS:                tls,
+		Paths:              paths,
+		Weight:             weight,
+	}
+}
+
+func buildGSLBHostRule(name, ns, gsFqdn string, sitePersistence *gslbalphav1.SitePersistence,
+	hmRefs []string, ttl *int) *gslbalphav1.GSLBHostRule {
+	return &gslbalphav1.GSLBHostRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: gslbalphav1.GSLBHostRuleSpec{
+			SitePersistence:   sitePersistence,
+			HealthMonitorRefs: hmRefs,
+			Fqdn:              gsFqdn,
+			TTL:               ttl,
+		},
+	}
+}
+
+func deleteGSLBHostRule(t *testing.T, name, ns string) {
+	err := gslbutils.GlobalGslbClient.AmkoV1alpha1().GSLBHostRules(ns).Delete(context.TODO(),
+		name, metav1.DeleteOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		t.Fatalf("error in deleting gslb hostrule %s/%s: %v", ns, name, err)
+	}
+}
+
+func addGSLBHostRule(t *testing.T, name, ns, gsFqdn string, hmRefs []string,
+	sitePersistence *gslbalphav1.SitePersistence, ttl *int,
+	status, errMsg string) *gslbalphav1.GSLBHostRule {
+
+	gslbHR := buildGSLBHostRule(name, ns, gsFqdn, sitePersistence, hmRefs, ttl)
+	newObj, err := gslbutils.GlobalGslbClient.AmkoV1alpha1().GSLBHostRules(ns).Create(context.TODO(),
+		gslbHR, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in creating a GSLB Host Rule object %v: %v", gslbHR, err)
+	}
+	t.Cleanup(func() {
+		deleteGSLBHostRule(t, name, ns)
+	})
+
+	VerifyGSLBHostRuleStatus(t, ns, name, status, errMsg)
+	return newObj
+}
+
+func updateGSLBHostRule(t *testing.T, gslbHRObj *gslbalphav1.GSLBHostRule, status, errMsg string) *gslbalphav1.GSLBHostRule {
+	newObj, err := gslbutils.GlobalGslbClient.AmkoV1alpha1().GSLBHostRules(gslbHRObj.Namespace).Update(context.TODO(),
+		gslbHRObj, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("error in creating a GSLB Host Rule object %v: %v", gslbHRObj, err)
+	}
+	VerifyGSLBHostRuleStatus(t, gslbHRObj.Namespace, gslbHRObj.Name, status, errMsg)
+	return newObj
+}
+
+func getGSLBHostRule(t *testing.T, name, ns string) *gslbalphav1.GSLBHostRule {
+	obj, err := gslbutils.GlobalGslbClient.AmkoV1alpha1().GSLBHostRules(ns).Get(context.TODO(),
+		name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error in getting GSLB HostRule %s/%s: %v", ns, name, err)
+	}
+	return obj
+}
+
+func VerifyGSLBHostRuleStatus(t *testing.T, ns, name, status, errMsg string) {
+	g := gomega.NewGomegaWithT(t)
+	g.Eventually(func() bool {
+		gslbHR, err := gslbutils.GlobalGslbClient.AmkoV1alpha1().GSLBHostRules(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to fetch GSLBHostRule object %s/%s: %v", ns, name, err)
+		}
+		if gslbHR.Status.Status != status || gslbHR.Status.Error != errMsg {
+			t.Logf("GSLB HostRule, expected status: %s, got: %s", status, gslbHR.Status.Status)
+			t.Logf("GSLB HostRule, expected err: %s, got: %s", errMsg, gslbHR.Status.Error)
+			return false
+		}
+		return true
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true), "GSLB Host Rule status should match")
+}
+
+func getDefaultHostRule(name, ns, lfqdn, gfqdn, status string) *akov1alpha1.HostRule {
+	return &akov1alpha1.HostRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: akov1alpha1.HostRuleSpec{
+			VirtualHost: akov1alpha1.HostRuleVirtualHost{
+				Fqdn: lfqdn,
+				Gslb: akov1alpha1.HostRuleGSLB{
+					Fqdn: gfqdn,
+				},
+			},
+		},
+		Status: akov1alpha1.HostRuleStatus{
+			Status: status,
+		},
+	}
+}
+
+func deleteHostRule(t *testing.T, cluster int, ns, name string) {
+	hrClient, err := hrcs.NewForConfig(cfgs[cluster])
+	if err != nil {
+		t.Fatalf("error in getting hostrule client for cluster %d: %v", cluster, err)
+	}
+
+	err = hrClient.AkoV1alpha1().HostRules(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		t.Fatalf("error in deleting hostrule for cluster %d: %v", cluster, err)
+	}
+}
+
+func createHostRule(t *testing.T, cluster int, hr *akov1alpha1.HostRule) *akov1alpha1.HostRule {
+	hrClient, err := hrcs.NewForConfig(cfgs[cluster])
+	if err != nil {
+		t.Fatalf("error in getting hostrule client for cluster %d: %v", cluster, err)
+	}
+
+	newHr, err := hrClient.AkoV1alpha1().HostRules(hr.Namespace).Create(context.TODO(), hr, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in creating hostrule for cluster %d: %v", cluster, err)
+	}
+	t.Cleanup(func() {
+		deleteHostRule(t, cluster, newHr.Namespace, newHr.Name)
+	})
+	return newHr
+}
+
+func updateHostRule(t *testing.T, cluster int, hr *akov1alpha1.HostRule) *akov1alpha1.HostRule {
+	hrClient, err := hrcs.NewForConfig(cfgs[cluster])
+	if err != nil {
+		t.Fatalf("error in getting hostrule client for cluster %d: %v", cluster, err)
+	}
+
+	newHr, err := hrClient.AkoV1alpha1().HostRules(hr.Namespace).Update(context.TODO(), hr, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("error in updating hostrule for cluster %d: %v", cluster, err)
+	}
+	return newHr
+}
+
+func getTestHostRule(t *testing.T, cluster int, name, ns string) *akov1alpha1.HostRule {
+	hrClient, err := hrcs.NewForConfig(cfgs[cluster])
+	if err != nil {
+		t.Fatalf("error in getting hostrule client for cluster %d: %v", cluster, err)
+	}
+
+	hr, err := hrClient.AkoV1alpha1().HostRules(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error in getting hostrule %s/%s: %v", ns, name, err)
+	}
+	return hr
+}
+
+func DeleteTestGDP(t *testing.T, ns, name string) error {
+	err := gslbutils.GlobalGdpClient.AmkoV1alpha2().GlobalDeploymentPolicies(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	t.Logf("deleted GDP %s in %s namespace", name, ns)
+	return nil
+}

--- a/gslb/test/integration/third_party_vips/int_test.go
+++ b/gslb/test/integration/third_party_vips/int_test.go
@@ -367,6 +367,7 @@ func AddTestGslbConfigObject() {
 		metav1.CreateOptions{})
 	if err != nil {
 		gslbutils.Errf("error in creating GSLBConfig object: %v", err)
+		return
 	}
 	g.Eventually(func() string {
 		gcObj, err := gcClient.AmkoV1alpha1().GSLBConfigs(AviSystemNS).Get(context.TODO(), GslbConfigName,


### PR DESCRIPTION
Fixes:
- GSLBHostRule was only allowed in `avi-system` namespace, that
  restriction has been removed.
- Segfault used to occur in this condition:
    Add a `GSLBHostRule` object which doesn't pertain to any GSLB
    service, AMKO used to create a GS graph for this (which wasn't
    required). And if the `GSLBHostRule` object gets deleted, we tried
    to fetch a GS from the cache (a key for the GS existed, but no
    actual graph). This would cause segfault in layer 2. Fix for this
    is to not do anything if there's no existing GS graph for a
    `GSLBHostRule`.
- We used to reject the `HostRules` if the status message said
  `Rejected`. However, this caused issues during transition when the
  object didn't have the status (the first time it gets added). We still
  considered that object. This is now fixed to consider a `HostRule`
  object only if it is `Accepted`.

Tests:
- Added a testsuite for custom global fqdn mode. Tests include:
  * Add host rules for ingress and route hostnames, verify GS graphs.
  * Invalid host rule transition to valid hostrule.
  * Valid host rule transition to invalid hostrule.
  * Multiple hostrules (one valid and other invalid) for an ingress
    hostname.
  * Added library functions.

TODO:
  * Move the common code between different integration suites (like
    envtest initialization) to a common package.