### PR TITLE
Figure out TLS ingress/route from HostRule

### DIFF
--- a/gslb/gslbutils/gslbutils.go
+++ b/gslb/gslbutils/gslbutils.go
@@ -549,10 +549,11 @@ func GetGSFromHmName(hmName string) (string, error) {
 // information only required for AMKO.
 type HostRuleMeta struct {
 	GSFqdn string
+	TLS    bool
 }
 
-func GetHostRuleMeta(gsFqdn string) HostRuleMeta {
-	return HostRuleMeta{gsFqdn}
+func GetHostRuleMeta(gsFqdn string, tls bool) HostRuleMeta {
+	return HostRuleMeta{GSFqdn: gsFqdn, TLS: tls}
 }
 
 var customFqdnMode bool

--- a/gslb/ingestion/event_handlers.go
+++ b/gslb/ingestion/event_handlers.go
@@ -524,7 +524,7 @@ func ReApplyObjectsOnHostRule(hr *akov1alpha1.HostRule, add bool, cname string, 
 			}
 		}
 		if !add && acceptedStore != nil {
-			_, rejectedList := acceptedStore.GetAllFilteredObjectsForClusterFqdn(filter.ApplyFqdnMapFilter, cname, gfqdn)
+			acceptedList, rejectedList := acceptedStore.GetAllFilteredObjectsForClusterFqdn(filter.ApplyFqdnMapFilter, cname, gfqdn)
 			if len(rejectedList) != 0 {
 				filteredRejectedList, err := filterObjListBasedOnFqdn(acceptedStore, rejectedList, hr.Spec.VirtualHost.Fqdn, o)
 				if err != nil {
@@ -545,6 +545,32 @@ func ReApplyObjectsOnHostRule(hr *akov1alpha1.HostRule, add bool, cname string, 
 					key := gslbutils.MultiClusterKey(gslbutils.ObjectDelete, objKey, cname, ns, sname)
 					k8swq[bkt].AddRateLimited(key)
 					gslbutils.Logf("cluster: %s, ns: %s, objType:%s, name: %s, key: %s, msg: added DELETE obj key",
+						cname, ns, o, sname, key)
+				}
+			}
+
+			if len(acceptedList) != 0 {
+				// send the objects in the accepted list for an update to layer 2. This is so that, even
+				// though the previous logics capture the ADD/DELETE events for the objects because of
+				// a hostrule change, they don't take care of the UPDATE events.
+				filteredAcceptedList, err := filterObjListBasedOnFqdn(acceptedStore, acceptedList, hr.Spec.VirtualHost.Fqdn, o)
+				if err != nil {
+					gslbutils.Errf("cluster: %s, localFqdn: %s, msg: error in filtering the accepted list",
+						cname, hr.Spec.VirtualHost.Fqdn)
+				}
+				gslbutils.Logf("ObjList: %v, msg: %s", filteredAcceptedList, "obj list will be updated")
+				for _, objName := range filteredAcceptedList {
+					cname, ns, sname, err := splitName(o, objName)
+					if err != nil {
+						gslbutils.Errf("cluster: %s, msg: couldn't process object, objtype: %s, name: %s, error, %s",
+							cname, o, objName, err)
+						continue
+					}
+
+					bkt := utils.Bkt(ns, numWorkers)
+					key := gslbutils.MultiClusterKey(gslbutils.ObjectUpdate, objKey, cname, ns, sname)
+					k8swq[bkt].AddRateLimited(key)
+					gslbutils.Logf("cluster: %s, ns: %s, objType:%s, name: %s, key: %s, msg: added UPDATE obj key",
 						cname, ns, o, sname, key)
 				}
 			}
@@ -649,10 +675,10 @@ func AddHostRuleEventHandler(numWorkers uint32, c *GSLBMemberController) cache.R
 				}
 				// gs fqdn is updated, write an UPDATE event for the previous fqdn and an ADD event
 				// for the new fqdn
+				DeleteFromHostRuleStore(hrStore, oldHr, c.name)
 				AddOrUpdateHostRuleStore(hrStore, newHr, c.name)
 				fqdnMap.DeleteFromFqdnMapping(oldGFqdn, oldLFqdn, c.name)
 				fqdnMap.AddUpdateToFqdnMapping(newGFqdn, newLFqdn, c.name)
-				DeleteFromHostRuleStore(hrStore, oldHr, c.name)
 				ReApplyObjectsOnHostRule(oldHr, false, c.name, numWorkers, c.workqueue)
 				ReApplyObjectsOnHostRule(newHr, true, c.name, numWorkers, c.workqueue)
 			} else if oldHrAccepted && !newHrAccepted {

--- a/gslb/ingestion/event_handlers.go
+++ b/gslb/ingestion/event_handlers.go
@@ -558,7 +558,7 @@ func ReApplyObjectsOnHostRule(hr *akov1alpha1.HostRule, add bool, cname string, 
 					gslbutils.Errf("cluster: %s, localFqdn: %s, msg: error in filtering the accepted list",
 						cname, hr.Spec.VirtualHost.Fqdn)
 				}
-				gslbutils.Logf("ObjList: %v, msg: %s", filteredAcceptedList, "obj list will be updated")
+				gslbutils.Logf("cluster: %s, ObjList: %v, msg: %s", cname, filteredAcceptedList, "obj list will be updated")
 				for _, objName := range filteredAcceptedList {
 					cname, ns, sname, err := splitName(o, objName)
 					if err != nil {

--- a/gslb/ingestion/member_controllers.go
+++ b/gslb/ingestion/member_controllers.go
@@ -191,6 +191,9 @@ func isHostRuleUpdated(oldHr *akov1alpha1.HostRule, newHr *akov1alpha1.HostRule)
 	if oldHr.Spec.VirtualHost.Gslb.Fqdn != newHr.Spec.VirtualHost.Gslb.Fqdn {
 		return true
 	}
+	if oldHr.Spec.VirtualHost.TLS != newHr.Spec.VirtualHost.TLS {
+		return true
+	}
 	return false
 }
 
@@ -200,7 +203,13 @@ func isHostRuleUpdated(oldHr *akov1alpha1.HostRule, newHr *akov1alpha1.HostRule)
 func AddOrUpdateHostRuleStore(clusterHRStore *store.ClusterStore,
 	hr *akov1alpha1.HostRule, cname string) {
 
-	hrMeta := gslbutils.GetHostRuleMeta(hr.Spec.VirtualHost.Gslb.Fqdn)
+	var tls bool
+	// there should be a certificate present in the host rule for us to consider that
+	// the ingress/route with this hostname can be considered a secure one
+	if hr.Spec.VirtualHost.TLS.SSLKeyCertificate.Name != "" {
+		tls = true
+	}
+	hrMeta := gslbutils.GetHostRuleMeta(hr.Spec.VirtualHost.Gslb.Fqdn, tls)
 	gslbutils.Debugf("cluster: %s, namespace: %s, hostRule: %s, updating hostrule store: %s", cname,
 		hr.Namespace, hr.Name, hr.Spec.VirtualHost.Fqdn)
 	clusterHRStore.AddOrUpdate(hrMeta, cname, hr.Namespace, hr.Spec.VirtualHost.Fqdn)

--- a/gslb/test/integration/custom_fqdn/hostrule_test.go
+++ b/gslb/test/integration/custom_fqdn/hostrule_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/nodes"
 	ingestion_test "github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/test/ingestion"
 	gdpalphav2 "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/apis/amko/v1alpha2"
+	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1alpha1"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -70,6 +71,27 @@ func addIngressAndRouteObjects(t *testing.T, testPrefix string) (*networkingv1be
 		ingHostIPMap, true)
 	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
 		routeCluster, host, routeIPAddr, true)
+	return ingObj, routeObj
+}
+
+func addInsecureIngressAndRouteObjects(t *testing.T, testPrefix string) (*networkingv1beta1.Ingress, *routev1.Route) {
+	ingName := testPrefix + "def-ing"
+	routeName := testPrefix + "def-route"
+	ns := "default"
+	host := testPrefix + ingestion_test.TestDomain1
+	ingIPAddr := "10.10.100.1"
+	routeIPAddr := "10.10.200.1"
+	ingHostIPMap := map[string]string{host: ingIPAddr}
+
+	t.Cleanup(func() {
+		k8sDeleteIngress(t, clusterClients[K8s], ingName, ns)
+		oshiftDeleteRoute(t, clusterClients[Oshift], routeName, ns)
+	})
+
+	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
+		ingHostIPMap, false)
+	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
+		routeCluster, host, routeIPAddr, false)
 	return ingObj, routeObj
 }
 
@@ -250,4 +272,126 @@ func TestHostRuleMultiple(t *testing.T) {
 	g.Eventually(func() bool {
 		return verifyGSMembers(t, expectedMembers, gfqdn1, utils.ADMIN_NS, hmRefs, nil, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Add insecure ingress and route objects, create a GDP object, create host rules with TLS cert
+// and verify whether the GS members are now TLS members.
+// Sequence:
+// 1. Add insecure ingress/route objects.
+// 2. Add hostrules for the above objects without TLS fields.
+// 3. Verify the members and HTTP health monitor for GS.
+// 4. Update the hostrules with TLS fields.
+// 5. Verify the members and HTTPS health monitor for GS.
+func TestHostRuleInsecureToSecure(t *testing.T) {
+	testPrefix := "hris-"
+	hrNameK8s := testPrefix + "hr"
+	hrNameOC := testPrefix + "hr"
+	gfqdn := "test-gs.avi.com"
+
+	addTestGDPWithProperties(t, nil, nil, nil)
+	ingObj, routeObj := addInsecureIngressAndRouteObjects(t, testPrefix)
+
+	var expectedMembers []nodes.AviGSK8sObj
+	g := gomega.NewGomegaWithT(t)
+
+	k8sHr := getDefaultHostRule(hrNameK8s, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+		gslbutils.HostRuleAccepted)
+	createHostRule(t, K8s, k8sHr)
+	ocHr := getDefaultHostRule(hrNameOC, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+		gslbutils.HostRuleAccepted)
+	createHostRule(t, Oshift, ocHr)
+
+	expectedMembers = []nodes.AviGSK8sObj{getTestGSMemberFromIng(t, ingObj, ingCluster, 1),
+		getTestGSMemberFromRoute(t, routeObj, routeCluster, 1)}
+	t.Logf("verifying members and GS properties for TLS")
+	g.Eventually(func() bool {
+		// the last parameter below indicates the type of health monitor (HTTP/HTTPS), in this case,
+		// it must be `false` indicating HTTP type.
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, nil, nil, nil, false)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	newK8sHr := getTestHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	testCert := akov1alpha1.HostRuleSecret{Name: "test-cert", Type: "test-type"}
+	newK8sHr.Spec.VirtualHost.TLS.SSLKeyCertificate = testCert
+	updateHostRule(t, K8s, newK8sHr)
+
+	newOcHr := getTestHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	newOcHr.Spec.VirtualHost.TLS.SSLKeyCertificate = testCert
+	updateHostRule(t, Oshift, newOcHr)
+
+	// members will also become TLS type once the host rules are updated above
+	for idx := range expectedMembers {
+		expectedMembers[idx].TLS = true
+	}
+	t.Logf("verifying members and GS properties for non-TLS")
+	g.Eventually(func() bool {
+		// the last parameter below indicates the type of health monitor (HTTP/HTTPS), in this case,
+		// it must be `true` indicating HTTPS type.
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, nil, nil, nil, true)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Add insecure ingress and route objects, create a GDP object, create host rules with TLS cert
+// and verify whether the GS members are now TLS members.
+// Sequence:
+// 1. Add insecure ingress/route objects.
+// 2. Add hostrules for the above objects with TLS fields.
+// 3. Verify the members and HTTPS health monitor for GS.
+// 4. Update the hostrules with TLS fields removed.
+// 5. Verify the members and HTTP health monitor for GS.
+func TestHostRuleSecureToInsecure(t *testing.T) {
+	testPrefix := "hrsi-"
+	hrNameK8s := testPrefix + "hr"
+	hrNameOC := testPrefix + "hr"
+	gfqdn := "test-gs.avi.com"
+
+	addTestGDPWithProperties(t, nil, nil, nil)
+	ingObj, routeObj := addInsecureIngressAndRouteObjects(t, testPrefix)
+
+	var expectedMembers []nodes.AviGSK8sObj
+	g := gomega.NewGomegaWithT(t)
+
+	testCert := akov1alpha1.HostRuleSecret{Name: "test-cert", Type: "test-type"}
+
+	k8sHr := getDefaultHostRule(hrNameK8s, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+		gslbutils.HostRuleAccepted)
+	k8sHr.Spec.VirtualHost.TLS.SSLKeyCertificate = testCert
+	createHostRule(t, K8s, k8sHr)
+	ocHr := getDefaultHostRule(hrNameOC, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+		gslbutils.HostRuleAccepted)
+	ocHr.Spec.VirtualHost.TLS.SSLKeyCertificate = testCert
+	createHostRule(t, Oshift, ocHr)
+
+	expectedMembers = []nodes.AviGSK8sObj{getTestGSMemberFromIng(t, ingObj, ingCluster, 1),
+		getTestGSMemberFromRoute(t, routeObj, routeCluster, 1)}
+	// members will become TLS type once the host rules are created with TLS fields
+	for idx := range expectedMembers {
+		expectedMembers[idx].TLS = true
+	}
+	t.Logf("verifying for members and GS properties for non-TLS")
+	g.Eventually(func() bool {
+		// the last parameter below indicates the type of health monitor (HTTP/HTTPS), in this case,
+		// it must be `true` indicating HTTPS type.
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, nil, nil, nil, true)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// remove the TLS fields from the hostrules
+	newK8sHr := getTestHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	newK8sHr.Spec.VirtualHost.TLS.SSLKeyCertificate = akov1alpha1.HostRuleSecret{}
+	updateHostRule(t, K8s, newK8sHr)
+
+	newOcHr := getTestHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	newOcHr.Spec.VirtualHost.TLS.SSLKeyCertificate = akov1alpha1.HostRuleSecret{}
+	updateHostRule(t, Oshift, newOcHr)
+
+	// members will become non-TLS type once the host rules are updated above
+	for idx := range expectedMembers {
+		expectedMembers[idx].TLS = false
+	}
+	t.Logf("verifying for members and GS properties for TLS")
+	g.Eventually(func() bool {
+		// the last parameter below indicates the type of health monitor (HTTP/HTTPS), in this case,
+		// it must be `false` indicating HTTP type.
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, nil, nil, nil, false)
+	}, 10*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }


### PR DESCRIPTION
An insecure ingress/route can still be considered as a secure if the
HostRule corresponding to the relevant host fqdn has a TLS cert
attached to it. AMKO today doesn't consider the TLS fields in the
HostRule to determine the type of the member objects. This patch
aims to fix that.

This patch will also send UPDATE events for the affected objects (on
HostRule change event) to layer 2. This will take care of the
transition cases where a TLS cert may get added/removed from the
HostRule.

Ingestion Layer:
- Find out the accepted objects for a given HostRule. If that HostRule
  is changed, push UPDATE events for these objects to layer 2.
- Add TLS field as part of the HostRule meta object.

Graph layer:
- Universal function to determine the type of TLS for a member. First
  check if the native object is itself of type TLS. If yes, return true.
  Else, determine the type from the corresponding HostRule.

No Rest layer changes.

Integration test cases added:
- Add insecure ingress/route to clusters. Cover transition case of
  a non-TLS HostRule to TLS HostRule. Verify the type of HealthMonitor
  for the GS. Verify the GS member types as well.
- Add insecure ingress/route to clusters. Cover transition case of
  a TLS HostRule to non-TLS HostRule. Verify the members and GS
  properties.