### PR TITLE
Don't remove health monitors if HM ref is provided

### DIFF
--- a/gslb/ingestion/event_handlers.go
+++ b/gslb/ingestion/event_handlers.go
@@ -299,7 +299,7 @@ func AddIngressEventHandler(numWorkers uint32, c *GSLBMemberController) cache.Re
 			oldIngr, okOld := old.(*networkingv1beta1.Ingress)
 			ingr, okNew := curr.(*networkingv1beta1.Ingress)
 			if !okOld || !okNew {
-				containerutils.AviLog.Errorf("Unable to convert obj type interface to networking/v1beta1 ingress")
+				gslbutils.Errf("Unable to convert obj type interface to networking/v1beta1 ingress")
 				return
 			}
 			if oldIngr.ResourceVersion != ingr.ResourceVersion {


### PR DESCRIPTION
In rest layer, after removing the GS object, check if the GS contains
HM refs. If yes, don't delete the HM refs.

Also adds an additional test for ingress without status field.