### PR TITLE
VS UUID fix and aviserver integration test cases

### DIFF
--- a/gslb/nodes/dq_ingestion.go
+++ b/gslb/nodes/dq_ingestion.go
@@ -415,7 +415,10 @@ func DeleteAndAddGSGraphForFqdn(agl *AviGSGraphLister, oldFqdn, newFqdn, key, cn
 			aviGS.(*AviGSObjectGraph).Name, newFqdn)
 		aviGSGraph := aviGS.(*AviGSObjectGraph)
 		for _, m := range members {
-			aviGSGraph.AddUpdateGSMember(m)
+			deleteMember := aviGSGraph.AddUpdateGSMember(m)
+			if deleteMember {
+				aviGSGraph.DeleteMember(m.Cluster, m.Namespace, m.Name, m.ObjType)
+			}
 		}
 		agl.Save(newFqdn, aviGS.(*AviGSObjectGraph))
 		PublishKeyToRestLayer(utils.ADMIN_NS, newFqdn, key, sharedQ, oldFqdn)

--- a/gslb/test/ingestion/ingresses_test.go
+++ b/gslb/test/ingestion/ingresses_test.go
@@ -824,10 +824,6 @@ func k8sAddIngressWithoutStatus(t *testing.T, kc *k8sfake.Clientset, name string
 	return ingObj
 }
 
-func BuildIngressObj(name, ns, svc, cname string, hostIPs map[string]string, withStatus bool) *networkingv1beta1.Ingress {
-	return buildIngressObj(name, ns, svc, cname, hostIPs, withStatus)
-}
-
 func buildIngressObj(name, ns, svc, cname string, hostIPs map[string]string, withStatus bool) *networkingv1beta1.Ingress {
 	ingObj := &networkingv1beta1.Ingress{}
 	ingObj.Namespace = ns

--- a/gslb/test/integration/third_party_vips/int_test.go
+++ b/gslb/test/integration/third_party_vips/int_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/gslbutils"
 	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/ingestion"
 	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/nodes"
+	amkorest "github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/rest"
 	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/test/mockaviserver"
 	gslbalphav1 "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/apis/amko/v1alpha1"
 	gdpalphav2 "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/apis/amko/v1alpha2"
@@ -194,7 +195,8 @@ func SetUpTestWorkerQueues() {
 
 	// Set workers for layer 3 (REST layer)
 	graphSharedQueue := utils.SharedWorkQueue().GetQueueByName(utils.GraphLayer)
-	graphSharedQueue.SyncFunc = SyncFromTestNodesLayer
+	graphSharedQueue.SyncFunc = amkorest.SyncFromNodesLayer
+	// graphSharedQueue.SyncFunc = SyncFromTestNodesLayer
 	graphSharedQueue.Run(stopCh, gslbutils.GetWaitGroupFromMap(gslbutils.WGGraph))
 }
 


### PR DESCRIPTION
Bugfix:
If annotations are removed for an object in the VS UUID mode, we ignore
any updates to that member. This is incorrect, as we should be deleting
the member on removal of annotations. The fix is in layer 2, where,
upon seeing that the annotations are absent, we delete the gs member
from the gs graph and send the key to layer 3.

Integration tests enhancements:
- Added middlewares for Post/Put calls for GS and HM objects.
- Added library handlers to insert the middlewares.