### PR TITLE
Fix custom HM delete issue while bootup

### DIFF
--- a/gslb/gslbutils/gslbutils.go
+++ b/gslb/gslbutils/gslbutils.go
@@ -547,6 +547,16 @@ func BuildNonPathHmName(gsName string) string {
 	return "amko--" + gsName
 }
 
+// hmCreatedByAMKO checks if the health monitor is created by AMKO by checking the prefix of the
+// HM name. If the prefix "amko" exists for the HM name, we return true, else false.
+func HMCreatedByAMKO(hmName string) bool {
+	hmNameSplit := strings.Split(hmName, "--")
+	if len(hmNameSplit) >= 2 && hmNameSplit[0] == "amko" {
+		return true
+	}
+	return false
+}
+
 func GetGSFromHmName(hmName string) (string, error) {
 	// for path based hms
 	hmNameSplit := strings.Split(hmName, "--")

--- a/gslb/rest/dq_nodes.go
+++ b/gslb/rest/dq_nodes.go
@@ -1084,6 +1084,10 @@ func (restOp *RestOperations) deleteGSOper(gsCacheObj *avicache.AviGSCache, tena
 		// if no HM refs for this GS, delete all HMs for this GS
 		if len(gsGraph.HmRefs) == 0 {
 			for _, hmName := range gsCacheObj.HealthMonitorNames {
+				// check if this HM is created by AMKO, if not, don't try to remove it
+				if !gslbutils.HMCreatedByAMKO(hmName) {
+					continue
+				}
 				err = restOp.deleteHmIfRequired(gsName, tenant, key, gsCacheObj, gsKey, hmName)
 				if err != nil {
 					return


### PR DESCRIPTION
Bug: AMKO tries to delete the custom health monitor while booting up.

Conditions:
- Pre-existing Gslb Services on the controller.
- No ingress/routes or no GDP object.
- AMKO is booting up.

Cause:
While booting up, AMKO fetches the list of existing GSs. It then tries
to fetch the ingresses from the member clusters. If AMKO can't find
an ingress/route for an existing GS, it triggers a delete of that
GS object and it's corresponding Health monitor. In the rest layer,
AMKO checks if the GS graph has custom Health Monitors, if yes, it won't
delete the HMs.
However, during bootup, we don't have a GS graph, as the corresponding
cluster objects/GDP object is removed. Hence, the rest layer check of
custom HM won't work.

Fix:
For each health monitor that we try to delete in the rest layer, we
need to check if the health monitor was created by AMKO by checking the
prefix of the health monitor name.