### PR TITLE
Fixes for custom HM change and algorithm parsing

### DIFF
--- a/gslb/cache/controller_obj_cache.go
+++ b/gslb/cache/controller_obj_cache.go
@@ -426,7 +426,7 @@ func ParsePoolAlgorithmSettingsFromPool(gsPool models.GslbPool) *gslbalphav1.Poo
 }
 
 func ParsePoolAlgorithmSettings(algorithm *string, fallbackAlgorithm *string, consistentHashMask *int32) *gslbalphav1.PoolAlgorithmSettings {
-	if algorithm != nil {
+	if algorithm == nil {
 		return nil
 	}
 	pa := gslbalphav1.PoolAlgorithmSettings{LBAlgorithm: *algorithm}

--- a/gslb/nodes/avi_model_nodes.go
+++ b/gslb/nodes/avi_model_nodes.go
@@ -218,7 +218,7 @@ func (v *AviGSObjectGraph) CalculateChecksum() {
 	}
 
 	hmNames := []string{}
-	if len(v.HmRefs) > 0 {
+	if len(v.HmRefs) == 0 {
 		if v.Hm.Name != "" {
 			hmNames = append(hmNames, v.Hm.Name)
 		} else {


### PR DESCRIPTION
- If we change the custom health monitor in the GDP or the GSLBHostRule
  object to a different ref, AMKO doesn't react to it. This is because
  of an incorrect check in layer 2 for checksum calculation. We need to
  check if there are custom health monitor references, if yes, build a
  list for them and take them into account for checksum calculation.

- Parsing for pool algorithm settings in the rest layer was incorrect.
  Fixed it.