### PR TITLE
React to local fqdn update in AKO HostRule

### DIFF
--- a/gslb/ingestion/event_handlers.go
+++ b/gslb/ingestion/event_handlers.go
@@ -667,7 +667,7 @@ func AddHostRuleEventHandler(numWorkers uint32, c *GSLBMemberController) cache.R
 			newGFqdn := newHr.Spec.VirtualHost.Gslb.Fqdn
 			newLFqdn := newHr.Spec.VirtualHost.Fqdn
 			fqdnMap := gslbutils.GetFqdnMap()
-			if (oldHrAccepted == newHrAccepted) && newHrAccepted == true {
+			if (oldHrAccepted == newHrAccepted) && newHrAccepted {
 				// check if an update is required?
 				if !isHostRuleUpdated(oldHr, newHr) {
 					// no updates to the gs fqdn, so return

--- a/gslb/ingestion/member_controllers.go
+++ b/gslb/ingestion/member_controllers.go
@@ -188,6 +188,9 @@ func isHostRuleAcceptable(hr *akov1alpha1.HostRule) bool {
 }
 
 func isHostRuleUpdated(oldHr *akov1alpha1.HostRule, newHr *akov1alpha1.HostRule) bool {
+	if oldHr.Spec.VirtualHost.Fqdn != newHr.Spec.VirtualHost.Fqdn {
+		return true
+	}
 	if oldHr.Spec.VirtualHost.Gslb.Fqdn != newHr.Spec.VirtualHost.Gslb.Fqdn {
 		return true
 	}


### PR DESCRIPTION
Currently AMKO doesn't react on the local fqdn update provided in the
AKO HostRule. This fix checks if we have a mismatch in the old and new
local fqdn in the AKO HostRule. If yes, we send an delete + add event
to layer 2.