### PR TITLE
Fix for member cluster healthcheck

### DIFF
--- a/gslb/nodes/dq_ingestion.go
+++ b/gslb/nodes/dq_ingestion.go
@@ -132,7 +132,7 @@ func AddUpdateGSLBHostRuleOperation(key, objType, objName string, wq *utils.Work
 	found, aviGS := agl.Get(modelName)
 	if !found {
 		// no existing GS for the GS FQDN
-		gslbutils.Logf("key: %s, msg: no GS for the GS FQDN in host rule, will return")
+		gslbutils.Logf("key: %s, msg: no GS for the GS FQDN in host rule, will return", key)
 		return
 	}
 	gsGraph := aviGS.(*AviGSObjectGraph)

--- a/gslb/test/integration/custom_fqdn/custom_fqdn_test.go
+++ b/gslb/test/integration/custom_fqdn/custom_fqdn_test.go
@@ -256,7 +256,10 @@ func GetTestEnvClustersAsGslbMembers(arg1 string, arg2 []gslbalphav1.MemberClust
 
 	memberClusterList := make([]*ingestion.GSLBMemberController, 0)
 	for idx, c := range testClustersContexts {
-		member := ingestion.InitializeMemberCluster(cfgs[idx], c, clients)
+		member, err := ingestion.InitializeMemberCluster(cfgs[idx], c, clients)
+		if err != nil {
+			return nil, err
+		}
 		gslbutils.Logf("test cluster: %s, informers set up", c.GetClusterContextName())
 		memberClusterList = append(memberClusterList, member)
 	}

--- a/gslb/test/integration/third_party_vips/int_test.go
+++ b/gslb/test/integration/third_party_vips/int_test.go
@@ -258,7 +258,10 @@ func GetTestEnvClustersAsGslbMembers(arg1 string, arg2 []gslbalphav1.MemberClust
 
 	memberClusterList := make([]*ingestion.GSLBMemberController, 0)
 	for idx, c := range testClustersContexts {
-		member := ingestion.InitializeMemberCluster(cfgs[idx], c, clients)
+		member, err := ingestion.InitializeMemberCluster(cfgs[idx], c, clients)
+		if err != nil {
+			return nil, err
+		}
 		gslbutils.Logf("test cluster: %s, informers set up", c.GetClusterContextName())
 		memberClusterList = append(memberClusterList, member)
 	}


### PR DESCRIPTION
AMKO isn't shutting down if any one of the member cluster's healthcheck
fails. The error wasn't returned to the calling function
`AddGSLBConfigObject`. This PR fixes it by passing the cluster healthcheck
error (if any) to the calling function.