### PR TITLE
Add infinite retry for errors other than 404

### DIFF
--- a/gslb/cache/controller_obj_cache.go
+++ b/gslb/cache/controller_obj_cache.go
@@ -148,7 +148,7 @@ func (h *AviHmCache) AviHmObjCachePopulate(client *clients.AviClient, hmname ...
 		} else if nextPageURI != "" {
 			uri = nextPageURI
 		}
-		result, err := gslbutils.GetUriFromAvi(uri+"&is_federated=true", client)
+		result, err := gslbutils.GetUriFromAvi(uri+"&is_federated=true", client, false)
 		if err != nil {
 			return errors.New("object: AviCache, msg: HealthMonitor get URI " + uri + " returned error: " + err.Error())
 		}
@@ -296,7 +296,7 @@ func (c *AviCache) AviObjGSCachePopulate(client *clients.AviClient, gsname ...st
 		} else if nextPageURI != "" {
 			uri = nextPageURI
 		}
-		result, err := gslbutils.GetUriFromAvi(uri+"&created_by="+gslbutils.AmkoUser, client)
+		result, err := gslbutils.GetUriFromAvi(uri+"&created_by="+gslbutils.AmkoUser, client, false)
 		if err != nil {
 			gslbutils.Warnf("object: AviCache, msg: GS get URI %s returned error: %s", uri, err)
 			return
@@ -795,7 +795,7 @@ func VerifyVersion() error {
 	uri := "/api/cloud"
 
 	// we don't actually need the cloud object, rather we want to see if the version is fine or not
-	_, err := gslbutils.GetUriFromAvi(uri, aviClient)
+	_, err := gslbutils.GetUriFromAvi(uri, aviClient, false)
 	if err != nil {
 		gslbutils.Errf("error: get URI %s returned error: %s", uri, err)
 		return err

--- a/gslb/gslbutils/constants.go
+++ b/gslb/gslbutils/constants.go
@@ -14,7 +14,11 @@
 
 package gslbutils
 
-import gdpalphav2 "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/apis/amko/v1alpha2"
+import (
+	"time"
+
+	gdpalphav2 "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/apis/amko/v1alpha2"
+)
 
 const (
 	// GSLBKubePath is a temporary path to put the kubeconfig
@@ -89,4 +93,7 @@ const (
 	// HostRule status constants
 	HostRuleAccepted = "Accepted"
 	HostRuleRejected = "Rejected"
+
+	// Wait time before a new rest call is made for retries
+	RestSleepTime = 5 * time.Second
 )

--- a/gslb/ingestion/gdp_controller.go
+++ b/gslb/ingestion/gdp_controller.go
@@ -320,7 +320,7 @@ func GDPSanityChecks(gdp *gdpalphav2.GlobalDeploymentPolicy) error {
 	// Health monotor validity
 	if len(gdp.Spec.HealthMonitorRefs) != 0 {
 		for _, hmRef := range gdp.Spec.HealthMonitorRefs {
-			if !isHealthMonitorRefValid(hmRef) {
+			if !isHealthMonitorRefValid(hmRef, true) {
 				return fmt.Errorf("health monitor ref %s is invalid", hmRef)
 			}
 		}


### PR DESCRIPTION
While fetching objects to verify refs for GDP object, we don't retry
infinitely today. This may pose a problem in situations where the
connection between AMKO and the Avi Controller has broken for sometime.
To handle this, we can retry infinitely for get requests for the refs
present in the GDP object.