### PR TITLE
Fix checksum calculation for GSs

### DIFF
--- a/gslb/cache/controller_obj_cache.go
+++ b/gslb/cache/controller_obj_cache.go
@@ -169,23 +169,22 @@ func (h *AviHmCache) AviHmObjCachePopulate(client *clients.AviClient, hmname ...
 				continue
 			}
 
-			if hm.MonitorPort == nil {
-				gslbutils.Warnf(spew.Sprintf("health monitor object doesn't have a monitor port, %v", hm))
-				continue
-			}
-
 			if hm.Name == nil || hm.UUID == nil {
 				gslbutils.Warnf("incomplete health monitor data unmarshalled %s", utils.Stringify(hm))
 				continue
 			}
 
 			k := TenantName{Tenant: utils.ADMIN_NS, Name: *hm.Name}
-			cksum := gslbutils.GetGSLBHmChecksum(*hm.Name, *hm.Type, *hm.MonitorPort)
+			var monitorPort int32
+			if hm.MonitorPort != nil {
+				monitorPort = *hm.MonitorPort
+			}
+			cksum := gslbutils.GetGSLBHmChecksum(*hm.Name, *hm.Type, monitorPort)
 			hmCacheObj := AviHmObj{
 				Name:             *hm.Name,
 				Tenant:           utils.ADMIN_NS,
 				UUID:             *hm.UUID,
-				Port:             *hm.MonitorPort,
+				Port:             monitorPort,
 				CloudConfigCksum: cksum,
 			}
 			h.AviHmCacheAdd(k, &hmCacheObj)


### PR DESCRIPTION
There are a couple of bugs today in checksum calculation. First one,
if there is a GDP object, and there's a GSLBHosRule object, and since,
we don't fetch the GSLBHosRule objects during boot up, we end up
making an unnecessary PUT request. Fix is to fetch the GSLBHosRule
objects during boot up.

Second one, if the health monitor used is `System-GSLB-Ping` or any
other health monitors which doesn't have the `monitor_port` field set,
we end up not storing that health monitor in our cache and hence, we
end up making PUT request on every reboot.