### PR TITLE
Add default algorithm in checksum

### DIFF
--- a/gslb/gslbutils/gdputils.go
+++ b/gslb/gslbutils/gdputils.go
@@ -304,7 +304,7 @@ func getChecksumForPoolAlgorithm(pa *gslbalphav1.PoolAlgorithmSettings) uint32 {
 	var cksum uint32
 
 	if pa == nil {
-		return cksum
+		return utils.Hash(gslbalphav1.PoolAlgorithmRoundRobin)
 	}
 
 	switch pa.LBAlgorithm {

--- a/gslb/rest/dq_nodes.go
+++ b/gslb/rest/dq_nodes.go
@@ -871,10 +871,6 @@ func (restOp *RestOperations) AviGSBuild(gsMeta *nodes.AviGSObjectGraph, restMet
 	if len(gsMeta.HmRefs) > 0 {
 		copy(hmRefs, gsMeta.HmRefs)
 	}
-	var ttl int32
-	if gsMeta.TTL != nil {
-		ttl = int32(*gsMeta.TTL)
-	}
 
 	gsAlgorithm := "GSLB_SERVICE_ALGORITHM_PRIORITY"
 	aviGslbSvc := avimodels.GslbService{
@@ -893,8 +889,14 @@ func (restOp *RestOperations) AviGSBuild(gsMeta *nodes.AviGSObjectGraph, restMet
 		WildcardMatch:                 &wildcardMatch,
 		TenantRef:                     &tenantRef,
 		Description:                   &description,
-		TTL:                           &ttl,
 	}
+
+	var ttl int32
+	if gsMeta.TTL != nil {
+		ttl = int32(*gsMeta.TTL)
+		aviGslbSvc.TTL = &ttl
+	}
+
 	if gsMeta.SitePersistenceRef != nil {
 		sitePersistenceEnabled := true
 		persistenceProfileRef := "/api/applicationpersistenceprofile?name=" + *gsMeta.SitePersistenceRef


### PR DESCRIPTION
If pool algorithm settings are not present in the GDP object, we don't
consider the default algorithm in the checksum calculation, although,
we add it as part of the GSLB Service in rest layer. This commit adds
the default pool algorithm as part of the checksum calculation.

Also, we always add TTL field to the GSLB Service, even when it isn't
a part of the GDP/GSLBHostRule object. This commit fixes that by
checking the TTL value first and then adding it as part of the
GSLBService in the rest layer.