### PR TITLE
Fix default algorithm for GSs

### DIFF
--- a/gslb/gslbutils/gdputils.go
+++ b/gslb/gslbutils/gdputils.go
@@ -304,7 +304,7 @@ func getChecksumForPoolAlgorithm(pa *gslbalphav1.PoolAlgorithmSettings) uint32 {
 	var cksum uint32
 
 	if pa == nil {
-		return utils.Hash(gslbalphav1.PoolAlgorithmRoundRobin)
+		return cksum
 	}
 
 	switch pa.LBAlgorithm {

--- a/gslb/nodes/node_utils.go
+++ b/gslb/nodes/node_utils.go
@@ -86,7 +86,13 @@ func setGSLBPropertiesForGS(gsFqdn string, gsGraph *AviGSObjectGraph, newObj boo
 		gsGraph.SitePersistenceRef = getSitePersistence(gsRuleExists, &gsRule, gf)
 	}
 
-	gsGraph.GslbPoolAlgorithm = getGslbPoolAlgorithm(gsRuleExists, &gsRule, gf)
+	pa := getGslbPoolAlgorithm(gsRuleExists, &gsRule, gf)
+	if pa == nil {
+		defaultAlgo := gslbalphav1.PoolAlgorithmSettings{LBAlgorithm: gslbalphav1.PoolAlgorithmRoundRobin}
+		gsGraph.GslbPoolAlgorithm = &defaultAlgo
+	} else {
+		gsGraph.GslbPoolAlgorithm = pa
+	}
 
 	if gsRuleExists && gsRule.ThirdPartyMembers != nil && len(gsRule.ThirdPartyMembers) != 0 {
 		if newObj {


### PR DESCRIPTION
For a nil value for gslb algorithm, the default value has to be
set while setting the gslb services. The default value was used
to calculate the checksum before and that was messing up the
checksum logic for GSLBHostRule.