### PR TITLE
Add handlers to fetch runtime data for AMKO

### DIFF
--- a/cmd/gslb/gscacheapi.go
+++ b/cmd/gslb/gscacheapi.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package main
+
+import (
+	"net/http"
+
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/apiserver"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/cache"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/api"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/api/models"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+)
+
+type GSCacheAPI struct{}
+
+func (g GSCacheAPI) InitModel() {}
+
+func (g GSCacheAPI) ApiOperationMap() []models.OperationMap {
+	get := models.OperationMap{
+		Route:   "/api/gscache",
+		Method:  "GET",
+		Handler: GSCacheHandler,
+	}
+	return []models.OperationMap{get}
+}
+
+func GSCacheHandler(w http.ResponseWriter, r *http.Request) {
+	aviCache := cache.GetAviCache()
+
+	names, ok := r.URL.Query()["name"]
+	if ok {
+		name := names[0]
+		key := cache.TenantName{Tenant: utils.ADMIN_NS, Name: name}
+		obj, present := aviCache.AviCacheGet(key)
+		if !present {
+			apiserver.WriteErrorToResponse(w)
+			return
+		}
+		apiserver.WriteToResponse(w, obj)
+		return
+	}
+	keys := aviCache.AviCacheGetAllKeys()
+	objs := []interface{}{}
+	for _, k := range keys {
+		obj, _ := aviCache.AviCacheGet(k)
+		gsObj := obj.(*cache.AviGSCache)
+		objs = append(objs, gsObj)
+	}
+	apiserver.WriteToResponse(w, objs)
+}
+
+func InitAmkoAPIServer() {
+	modelList := []models.ApiModel{
+		apiserver.AcceptedIngressAPI{},
+		apiserver.RejectedIngressAPI{},
+		apiserver.AcceptedLBSvcAPI{},
+		apiserver.RejectedLBSvcAPI{},
+		apiserver.AcceptedRouteAPI{},
+		apiserver.RejectedRouteAPI{},
+		apiserver.FilterAPI{},
+		apiserver.GslbHostRuleAPI{},
+		apiserver.GSGraphAPI{},
+		GSCacheAPI{},
+	}
+	amkoAPIServer := api.NewServer("8080", modelList)
+	amkoAPIServer.InitApi()
+
+	apiserver.SetAmkoAPIServer(amkoAPIServer)
+}

--- a/cmd/gslb/main.go
+++ b/cmd/gslb/main.go
@@ -15,11 +15,10 @@
 package main
 
 import (
-	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/gslbutils"
 	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/ingestion"
 )
 
 func main() {
-	gslbutils.InitAmkoAPIServer()
+	InitAmkoAPIServer()
 	ingestion.Initialize()
 }

--- a/gslb/apiserver/apiserver.go
+++ b/gslb/apiserver/apiserver.go
@@ -20,23 +20,6 @@ import (
 
 var amkoAPI *api.ApiServer
 
-// func InitAmkoAPIServer() {
-// 	modelList := []models.ApiModel{
-// 		AcceptedIngressAPI{},
-// 		RejectedIngressAPI{},
-// 		AcceptedLBSvcAPI{},
-// 		RejectedLBSvcAPI{},
-// 		AcceptedRouteAPI{},
-// 		RejectedRouteAPI{},
-// 		FilterAPI{},
-// 		GslbHostRuleAPI{},
-// 		GSGraphAPI{},
-// 	}
-// 	amkoAPIServer := api.NewServer("8080", modelList)
-// 	amkoAPIServer.InitApi()
-// 	amkoAPI = amkoAPIServer
-// }
-
 func SetAmkoAPIServer(server *api.ApiServer) {
 	amkoAPI = server
 }

--- a/gslb/apiserver/apiserver.go
+++ b/gslb/apiserver/apiserver.go
@@ -12,19 +12,33 @@
 * limitations under the License.
 */
 
-package gslbutils
+package apiserver
 
 import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/api"
-	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/api/models"
 )
 
 var amkoAPI *api.ApiServer
 
-func InitAmkoAPIServer() {
-	amkoAPIServer := api.NewServer("8080", []models.ApiModel{})
-	amkoAPIServer.InitApi()
-	amkoAPI = amkoAPIServer
+// func InitAmkoAPIServer() {
+// 	modelList := []models.ApiModel{
+// 		AcceptedIngressAPI{},
+// 		RejectedIngressAPI{},
+// 		AcceptedLBSvcAPI{},
+// 		RejectedLBSvcAPI{},
+// 		AcceptedRouteAPI{},
+// 		RejectedRouteAPI{},
+// 		FilterAPI{},
+// 		GslbHostRuleAPI{},
+// 		GSGraphAPI{},
+// 	}
+// 	amkoAPIServer := api.NewServer("8080", modelList)
+// 	amkoAPIServer.InitApi()
+// 	amkoAPI = amkoAPIServer
+// }
+
+func SetAmkoAPIServer(server *api.ApiServer) {
+	amkoAPI = server
 }
 
 func GetAmkoAPIServer() *api.ApiServer {

--- a/gslb/apiserver/graph.go
+++ b/gslb/apiserver/graph.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 VMware, Inc.
+ * Copyright 2021 VMware, Inc.
  * All Rights Reserved.
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/gslb/apiserver/graph.go
+++ b/gslb/apiserver/graph.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019-2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package apiserver
+
+import (
+	"net/http"
+
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/nodes"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/api/models"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+)
+
+type GSGraphAPI struct{}
+
+func (g GSGraphAPI) InitModel() {}
+
+func (g GSGraphAPI) ApiOperationMap() []models.OperationMap {
+	get := models.OperationMap{
+		Route:   "/api/gsgraph",
+		Method:  "GET",
+		Handler: GSGraphHandler,
+	}
+	return []models.OperationMap{get}
+}
+
+func GSGraphHandler(w http.ResponseWriter, r *http.Request) {
+	agl := nodes.SharedAviGSGraphLister()
+
+	names, ok := r.URL.Query()["name"]
+	if ok {
+		name := names[0]
+		tenName := utils.ADMIN_NS + "/" + name
+		_, aviGS := agl.Get(tenName)
+		if aviGS == nil {
+			WriteToResponse(w, nil)
+			return
+		}
+		aviGSGraph := aviGS.(*nodes.AviGSObjectGraph)
+		WriteToResponse(w, aviGSGraph)
+		return
+	}
+
+	keys := agl.GetAll()
+	results := []interface{}{}
+
+	for _, key := range keys {
+		_, aviGS := agl.Get(key)
+		aviGSGraph := aviGS.(*nodes.AviGSObjectGraph)
+		results = append(results, aviGSGraph.GetCopy())
+	}
+	WriteToResponse(w, results)
+}

--- a/gslb/apiserver/ingestion.go
+++ b/gslb/apiserver/ingestion.go
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2019-2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package apiserver
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/gslbutils"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/store"
+	gdpalphav2 "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/apis/amko/v1alpha2"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/api/models"
+)
+
+type FilterAPI struct{}
+
+func (f FilterAPI) InitModel() {}
+
+func (f FilterAPI) ApiOperationMap() []models.OperationMap {
+	get := models.OperationMap{
+		Route:   "/api/filter",
+		Method:  "GET",
+		Handler: FilterAPIGetHandler,
+	}
+	return []models.OperationMap{get}
+}
+
+func FilterAPIGetHandler(w http.ResponseWriter, r *http.Request) {
+	f := gslbutils.GetGlobalFilter()
+
+	gslbutils.Logf("fetching filter data")
+	w.Header().Add("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(f.GetCopy())
+}
+
+type GslbHostRuleAPI struct{}
+
+func (g GslbHostRuleAPI) InitModel() {}
+
+func (g GslbHostRuleAPI) ApiOperationMap() []models.OperationMap {
+	get := models.OperationMap{
+		Route:   "/api/ghrules",
+		Method:  "GET",
+		Handler: GhRuleAPIHandler,
+	}
+	return []models.OperationMap{get}
+}
+
+func GhRuleAPIHandler(w http.ResponseWriter, r *http.Request) {
+	keys := r.URL.Query()
+	fqdns, ok := r.URL.Query()["fqdn"]
+	if !ok && len(keys) != 0 {
+		gslbutils.Logf("unsupported keys: %v", keys)
+		return
+	}
+	ghRuleList := gslbutils.GetGSHostRulesList()
+	if len(fqdns) > 0 {
+		gsFqdn := fqdns[0]
+		rules := ghRuleList.GetGSHostRulesForFQDN(gsFqdn)
+		WriteToResponse(w, rules)
+		return
+	} else {
+		rules := ghRuleList.GetAllGSHostRules()
+		WriteToResponse(w, rules)
+		return
+	}
+}
+
+func WriteToResponse(w http.ResponseWriter, data interface{}) {
+	w.Header().Add("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(data)
+}
+
+func WriteErrorToResponse(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusBadRequest)
+	w.Write([]byte(`{"error": "Bad Request"}`))
+}
+
+type AcceptedIngressAPI struct{}
+
+func (ai AcceptedIngressAPI) InitModel() {}
+
+func (ai AcceptedIngressAPI) ApiOperationMap() []models.OperationMap {
+	get := models.OperationMap{
+		Route:   "/api/accepted/ingress",
+		Method:  "GET",
+		Handler: AcceptedIngressAPIHandler,
+	}
+	return []models.OperationMap{get}
+}
+
+func AcceptedIngressAPIHandler(w http.ResponseWriter, r *http.Request) {
+	FetchIngestionObjectsAndRespond(w, r, gdpalphav2.IngressObj, true)
+}
+
+type RejectedIngressAPI struct{}
+
+func (ai RejectedIngressAPI) InitModel() {}
+
+func (ri RejectedIngressAPI) ApiOperationMap() []models.OperationMap {
+	get := models.OperationMap{
+		Route:   "/api/rejected/ingress",
+		Method:  "GET",
+		Handler: RejectedIngressAPIHandler,
+	}
+	return []models.OperationMap{get}
+}
+
+func RejectedIngressAPIHandler(w http.ResponseWriter, r *http.Request) {
+	FetchIngestionObjectsAndRespond(w, r, gdpalphav2.IngressObj, false)
+}
+
+type AcceptedRouteAPI struct{}
+
+func (ar AcceptedRouteAPI) InitModel() {}
+
+func (ar AcceptedRouteAPI) ApiOperationMap() []models.OperationMap {
+	get := models.OperationMap{
+		Route:   "/api/accepted/route",
+		Method:  "GET",
+		Handler: AcceptedRouteAPIHandler,
+	}
+	return []models.OperationMap{get}
+}
+
+func AcceptedRouteAPIHandler(w http.ResponseWriter, r *http.Request) {
+	FetchIngestionObjectsAndRespond(w, r, gdpalphav2.RouteObj, true)
+}
+
+type RejectedRouteAPI struct{}
+
+func (rr RejectedRouteAPI) InitModel() {}
+
+func (rr RejectedRouteAPI) ApiOperationMap() []models.OperationMap {
+	get := models.OperationMap{
+		Route:   "/api/rejected/route",
+		Method:  "GET",
+		Handler: RejectedRouteAPIHandler,
+	}
+	return []models.OperationMap{get}
+}
+
+func RejectedRouteAPIHandler(w http.ResponseWriter, r *http.Request) {
+	FetchIngestionObjectsAndRespond(w, r, gdpalphav2.RouteObj, false)
+}
+
+type AcceptedLBSvcAPI struct{}
+
+func (as AcceptedLBSvcAPI) InitModel() {}
+
+func (as AcceptedLBSvcAPI) ApiOperationMap() []models.OperationMap {
+	get := models.OperationMap{
+		Route:   "/api/accepted/lbsvc",
+		Method:  "GET",
+		Handler: AcceptedLBSvcAPIHandler,
+	}
+	return []models.OperationMap{get}
+}
+
+func AcceptedLBSvcAPIHandler(w http.ResponseWriter, r *http.Request) {
+	FetchIngestionObjectsAndRespond(w, r, gdpalphav2.LBSvcObj, true)
+}
+
+type RejectedLBSvcAPI struct{}
+
+func (rs RejectedLBSvcAPI) InitModel() {}
+
+func (rs RejectedLBSvcAPI) ApiOperationMap() []models.OperationMap {
+	get := models.OperationMap{
+		Route:   "/api/rejected/lbsvc",
+		Method:  "GET",
+		Handler: RejectedLBSvcAPIHandler,
+	}
+	return []models.OperationMap{get}
+}
+
+func RejectedLBSvcAPIHandler(w http.ResponseWriter, r *http.Request) {
+	FetchIngestionObjectsAndRespond(w, r, gdpalphav2.LBSvcObj, false)
+}
+
+func FetchIngestionObjectsAndRespond(w http.ResponseWriter, r *http.Request, objType string, accepted bool) {
+	var cluster, ns, name string
+
+	clusters, ok := r.URL.Query()["cluster"]
+	if ok {
+		cluster = clusters[0]
+	}
+
+	nss, ok := r.URL.Query()["ns"]
+	if ok {
+		ns = nss[0]
+	}
+
+	names, ok := r.URL.Query()["name"]
+	if ok {
+		name = names[0]
+	}
+
+	var objList *store.ClusterStore
+
+	if objType == gdpalphav2.RouteObj {
+		if accepted {
+			objList = store.GetAcceptedRouteStore()
+		} else {
+			objList = store.GetRejectedRouteStore()
+		}
+	} else if objType == gdpalphav2.LBSvcObj {
+		if accepted {
+			objList = store.GetAcceptedLBSvcStore()
+		} else {
+			objList = store.GetRejectedLBSvcStore()
+		}
+	} else if objType == gdpalphav2.IngressObj {
+		if accepted {
+			objList = store.GetAcceptedIngressStore()
+		} else {
+			objList = store.GetRejectedIngressStore()
+		}
+	} else {
+		gslbutils.Errf("Unknown Object type: %s", objType)
+		WriteErrorToResponse(w)
+		return
+	}
+
+	objects := objList.GetAllClusterNSObjects()
+	result := []interface{}{}
+	for _, o := range objects {
+		cname, namespace, sname, err := splitName(gdpalphav2.IngressObj, o)
+		if err != nil {
+			gslbutils.Logf("can't split name for object: %s", o)
+			continue
+		}
+		if cluster != "" && cluster != cname {
+			continue
+		}
+		if ns != "" && ns != namespace {
+			continue
+		}
+		if name != "" && name != sname {
+			continue
+		}
+		obj, ok := objList.GetClusterNSObjectByName(cname, namespace, sname)
+		if !ok {
+			gslbutils.Logf("couldn't find object: %s", o)
+			continue
+		}
+		result = append(result, obj)
+	}
+	WriteToResponse(w, result)
+}
+
+func splitName(objType, objName string) (string, string, string, error) {
+	var cname, ns, sname, hostname string
+	var err error
+	if objType == gdpalphav2.IngressObj {
+		cname, ns, sname, hostname, err = gslbutils.SplitMultiClusterIngHostName(objName)
+		sname += "/" + hostname
+	} else {
+		cname, ns, sname, err = gslbutils.SplitMultiClusterObjectName(objName)
+	}
+	return cname, ns, sname, err
+}

--- a/gslb/cache/controller_obj_cache.go
+++ b/gslb/cache/controller_obj_cache.go
@@ -30,6 +30,7 @@ import (
 	"github.com/avinetworks/sdk/go/models"
 	"github.com/avinetworks/sdk/go/session"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/apiserver"
 	gslbalphav1 "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/apis/amko/v1alpha1"
 	apimodels "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/api/models"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
@@ -769,7 +770,7 @@ func VerifyVersion() error {
 	aviRestClientPool := SharedAviClients()
 	if len(aviRestClientPool.AviClient) < 1 {
 		gslbutils.Errf("no avi clients initialized, returning")
-		gslbutils.GetAmkoAPIServer().ShutDown()
+		apiserver.GetAmkoAPIServer().ShutDown()
 		return errors.New("no avi clients initialized")
 	}
 

--- a/gslb/gslbutils/gdputils.go
+++ b/gslb/gslbutils/gdputils.go
@@ -201,10 +201,6 @@ type AppFilter struct {
 	Label
 }
 
-// func (a AppFilter) GetCopy() *AppFilter {
-// 	label :=
-// }
-
 type NamespaceFilter struct {
 	Label
 	// SelectedNS contains a list of namespaces selected via this filter

--- a/gslb/gslbutils/gdputils.go
+++ b/gslb/gslbutils/gdputils.go
@@ -179,9 +179,31 @@ func (gf *GlobalFilter) GetGslbPoolAlgorithm() *gslbalphav1.PoolAlgorithmSetting
 	return gf.GslbPoolAlgorithm.DeepCopy()
 }
 
+func (gf *GlobalFilter) GetCopy() *GlobalFilter {
+	gf.GlobalLock.RLock()
+	defer gf.GlobalLock.RUnlock()
+
+	newFilter := GlobalFilter{
+		AppFilter:          gf.AppFilter,
+		NSFilter:           gf.NSFilter,
+		TrafficSplit:       gf.TrafficSplit,
+		ApplicableClusters: gf.ApplicableClusters,
+		HealthMonitorRefs:  gf.HealthMonitorRefs,
+		SitePersistenceRef: gf.SitePersistenceRef,
+		TTL:                gf.TTL,
+		GslbPoolAlgorithm:  gf.GslbPoolAlgorithm,
+		Checksum:           gf.Checksum,
+	}
+	return &newFilter
+}
+
 type AppFilter struct {
 	Label
 }
+
+// func (a AppFilter) GetCopy() *AppFilter {
+// 	label :=
+// }
 
 type NamespaceFilter struct {
 	Label

--- a/gslb/gslbutils/gslbhr_utils.go
+++ b/gslb/gslbutils/gslbhr_utils.go
@@ -167,6 +167,19 @@ func (ghrules *GSFqdnHostRules) GetGSHostRulesForFQDN(gsFqdn string) *GSHostRule
 	return nil
 }
 
+func (ghrules *GSFqdnHostRules) GetAllGSHostRules() []GSHostRules {
+	ghrules.GlobalLock.RLock()
+	defer ghrules.GlobalLock.RUnlock()
+
+	ghrs := []GSHostRules{}
+	for _, v := range ghrules.GSHostRuleList {
+		var ghr GSHostRules
+		v.DeepCopyInto(&ghr)
+		ghrs = append(ghrs, ghr)
+	}
+	return ghrs
+}
+
 func (ghrules *GSFqdnHostRules) BuildAndSetGSHostRulesForFQDN(gslbhr *gslbhralphav1.GSLBHostRule) {
 	newObj := GetGSHostRuleForGSLBHR(gslbhr)
 	ghrules.GlobalLock.Lock()

--- a/gslb/ingestion/gslb.go
+++ b/gslb/ingestion/gslb.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/apiserver"
 	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/gslbutils"
 	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/nodes"
 
@@ -569,7 +570,7 @@ func AddGSLBConfigObject(obj interface{}, initializeGSLBMemberClusters Initializ
 		gslbutils.Errf("couldn't initialize the kubernetes/openshift clusters: %s, returning", err.Error())
 		gslbutils.UpdateGSLBConfigStatus(ClusterHealthCheckErr + err.Error())
 		// shutdown the api server to let k8s/openshift restart the pod back up
-		gslbutils.GetAmkoAPIServer().ShutDown()
+		apiserver.GetAmkoAPIServer().ShutDown()
 		return
 	}
 

--- a/gslb/rest/dq_nodes.go
+++ b/gslb/rest/dq_nodes.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/apiserver"
 	avicache "github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/cache"
 
 	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/gslbutils"
@@ -656,7 +657,7 @@ func (restOp *RestOperations) PublishKeyToRetryLayer(gsKey, hmKey *avicache.Tena
 	case 401:
 		if strings.Contains(*aviError.Message, "Invalid credentials") {
 			gslbutils.Errf("key: %s, msg: credentials were invalid, shutting down API server", key)
-			gslbutils.GetAmkoAPIServer().ShutDown()
+			apiserver.GetAmkoAPIServer().ShutDown()
 			return
 		}
 		gslbutils.Errf("key: %s, msg: error code 401, will retry", key)


### PR DESCRIPTION
This PR uses the API server to fetch runtime objects from AMKO's memory.
It adds handlers for:
1. In Ingestion layer:
  - Accepted/Rejected objects for route, ingress, lb svc (these can also
    be queried by cluster, namespace and name).
  - Filter object (created from GDP)
  - HostRules (can be queried by fqdn)

2. In Graph layer:
  - All GS graphs (name based query is also supported)

An example:
```
curl -XGET <IP>:8080/api/gsgraph?name=green-ing1.avi.internal
```
Output:
```
{
    "Name": "green-ing1.avi.internal",
    "Tenant": "admin",
    "DomainNames": [
        "green-ing1.avi.internal"
    ],
    "MemberObjs": [
        {
            "Cluster": "k8s",
            "ObjType": "INGRESS",
[...]
```