### PR TITLE
Optimize health monitor and site persistence lookup

### DIFF
--- a/gslb/cache/controller_obj_cache.go
+++ b/gslb/cache/controller_obj_cache.go
@@ -291,7 +291,6 @@ func (s *AviSpCache) AviSitePersistenceCachePopulate(client *clients.AviClient) 
 				continue
 			}
 			gslbutils.Warnf("error in getting the nextURI, can't proceed further, next URI %s", result.Next)
-			break
 		}
 		break
 	}
@@ -851,15 +850,10 @@ func PopulateHMCache(createSharedCache bool) *AviHmCache {
 	return aviHmCache
 }
 
-func PopulateSPCache(createSharedCache bool) *AviSpCache {
+func PopulateSPCache() *AviSpCache {
 	aviRestClientPool := SharedAviClients()
-	var aviSpCache *AviSpCache
-	if createSharedCache {
-		aviSpCache = GetAviSpCache()
-	} else {
-		aviSpCache = &AviSpCache{}
-		aviSpCache.Cache = make(map[interface{}]interface{})
-	}
+	aviSpCache := &AviSpCache{}
+	aviSpCache.Cache = make(map[interface{}]interface{})
 	if len(aviRestClientPool.AviClient) > 0 {
 		aviSpCache.AviSitePersistenceCachePopulate(aviRestClientPool.AviClient[0])
 	}

--- a/gslb/ingestion/fullsync.go
+++ b/gslb/ingestion/fullsync.go
@@ -141,7 +141,7 @@ func checkGslbHostRulesAndInitialize() error {
 	gsHostRulesList := gslbutils.GetGSHostRulesList()
 	for _, gslbHr := range gslbhrList.Items {
 		gsFqdn := gslbHr.Spec.Fqdn
-		err := ValidateGSLBHostRule(&gslbHr)
+		err := ValidateGSLBHostRule(&gslbHr, true)
 		if err != nil {
 			updateGSLBHR(&gslbHr, err.Error(), GslbHostRuleRejected)
 			gslbutils.Errf("Error in accepting GSLB Host Rule %s : %v", gsFqdn, err)
@@ -188,7 +188,8 @@ func checkGDPsAndInitialize() error {
 	}
 
 	if successGDP != nil {
-		AddGDPObj(successGDP, nil, 0)
+		AddGDPObj(successGDP, nil, 0, true)
+		return nil
 	}
 
 	// no success GDPs, check if only one exists
@@ -196,7 +197,7 @@ func checkGDPsAndInitialize() error {
 		return errors.New("more than one GDP objects")
 	}
 
-	AddGDPObj(&gdpList.Items[0], nil, 0)
+	AddGDPObj(&gdpList.Items[0], nil, 0, true)
 	return nil
 }
 

--- a/gslb/ingestion/gslb.go
+++ b/gslb/ingestion/gslb.go
@@ -581,6 +581,7 @@ func AddGSLBConfigObject(obj interface{}, initializeGSLBMemberClusters Initializ
 	// boot up time cache population
 	gslbutils.Logf("will populate avi cache now...")
 	avicache.PopulateHMCache(true)
+	avicache.PopulateSPCache(true)
 	newCache := avicache.PopulateGSCache(true)
 
 	bootupSync(aviCtrlList, newCache)

--- a/gslb/ingestion/gslb.go
+++ b/gslb/ingestion/gslb.go
@@ -581,7 +581,7 @@ func AddGSLBConfigObject(obj interface{}, initializeGSLBMemberClusters Initializ
 	// boot up time cache population
 	gslbutils.Logf("will populate avi cache now...")
 	avicache.PopulateHMCache(true)
-	avicache.PopulateSPCache(true)
+	avicache.PopulateSPCache()
 	newCache := avicache.PopulateGSCache(true)
 
 	bootupSync(aviCtrlList, newCache)

--- a/gslb/test/ingestion/gdp_test.go
+++ b/gslb/test/ingestion/gdp_test.go
@@ -41,19 +41,24 @@ func TestGDPNewController(t *testing.T) {
 	gdpClient := gdpfake.NewSimpleClientset()
 	gdpInformerFactory := gdpinformers.NewSharedInformerFactory(gdpClient, time.Second*30)
 	gdpCtrl := gslbingestion.InitializeGDPController(gdpKubeClient, gdpClient, gdpInformerFactory, addSomething, updateSomething,
-		addSomething)
+		deleteSomething)
 	if gdpCtrl == nil {
 		t.Fatalf("GDP controller not set")
 	}
 }
 
 // addSomething is a dummy function used to initialize the GDP controller
-func addSomething(obj interface{}, k8swq []workqueue.RateLimitingInterface, numWorkers uint32) {
+func addSomething(obj interface{}, k8swq []workqueue.RateLimitingInterface, numWorkers uint32, fullSync bool) {
 
 }
 
 // updateSomething is a dummy function used to initialize the GDP controller
 func updateSomething(old, new interface{}, k8swq []workqueue.RateLimitingInterface, numWorkers uint32) {
+
+}
+
+// deleteSomething is a dummy function used to initialize the GDP controller
+func deleteSomething(old interface{}, k8swq []workqueue.RateLimitingInterface, numWorkers uint32) {
 
 }
 
@@ -512,7 +517,7 @@ func TestGDPSelectNoClusters(t *testing.T) {
 
 	t.Logf("gdp object: %v", gdp)
 	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
-	gslbingestion.AddGDPObj(gdp, ingestionQueue.Workqueue, 2)
+	gslbingestion.AddGDPObj(gdp, ingestionQueue.Workqueue, 2, false)
 
 	t.Logf("verifying keys")
 	for range allKeys {
@@ -552,7 +557,7 @@ func TestGDPSelectNoneObjsFromOneCluster(t *testing.T) {
 
 	t.Logf("gdp object: %v", gdp)
 	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
-	gslbingestion.AddGDPObj(gdp, ingestionQueue.Workqueue, 2)
+	gslbingestion.AddGDPObj(gdp, ingestionQueue.Workqueue, 2, false)
 
 	t.Logf("verifying keys")
 	VerifyAllKeys(t, allKeys, true)
@@ -595,7 +600,7 @@ func UpdateGDPMatchRuleAppLabel(gdp *gdpalphav2.GlobalDeploymentPolicy, key, val
 
 func AddTestGDPObj(gdp *gdpalphav2.GlobalDeploymentPolicy) {
 	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
-	gslbingestion.AddGDPObj(gdp, ingestionQueue.Workqueue, 2)
+	gslbingestion.AddGDPObj(gdp, ingestionQueue.Workqueue, 2, false)
 }
 
 func VerifyAllKeys(t *testing.T, allKeys []string, timeoutExpected bool) {

--- a/gslb/test/ingestion/gslbhostrule_test.go
+++ b/gslb/test/ingestion/gslbhostrule_test.go
@@ -49,7 +49,7 @@ func TestGSLBHostRuleValidThirdPartyMember(t *testing.T) {
 	gslbhrObj := getTestGSLBHRObject(gslbhrTestObjName, gslbhrTestNamespace, gslbhrTestFqdn)
 	gslbhrObj.Spec.ThirdPartyMembers = gslbhrThirdPartyMembers
 	t.Logf("Adding GSLBHostRule with Valid Third Party Members")
-	err := gslbingestion.ValidateGSLBHostRule(gslbhrObj)
+	err := gslbingestion.ValidateGSLBHostRule(gslbhrObj, false)
 	t.Logf("Verifying GSLBHostRule")
 	g.Expect(err).To(gomega.BeNil())
 	t.Logf("Verified GSLBHostRule")
@@ -66,7 +66,7 @@ func TestGSLBHostRuleInvalidThirdPartyMember(t *testing.T) {
 	gslbhrObj := getTestGSLBHRObject(gslbhrTestObjName, gslbhrTestNamespace, gslbhrTestFqdn)
 	gslbhrObj.Spec.ThirdPartyMembers = gslbhrThirdPartyMembers
 	t.Logf("Adding GSLBHostRule with invalid Third Party Members")
-	err := gslbingestion.ValidateGSLBHostRule(gslbhrObj)
+	err := gslbingestion.ValidateGSLBHostRule(gslbhrObj, false)
 	t.Logf("Verifying GSLBHostRule")
 	g.Expect(err).NotTo(gomega.BeNil())
 	t.Logf("Verified GSLBHostRule")
@@ -81,7 +81,7 @@ func TestGSLBHostRuleValidSitePersistence(t *testing.T) {
 	gslbhrObj := getTestGSLBHRObject(gslbhrTestObjName, gslbhrTestNamespace, gslbhrTestFqdn)
 	gslbhrObj.Spec.SitePersistence = gslbhrsp
 	t.Logf("Adding GSLBHostRule with Valid Site Persistences Profiles")
-	err := gslbingestion.ValidateGSLBHostRule(gslbhrObj)
+	err := gslbingestion.ValidateGSLBHostRule(gslbhrObj, false)
 	t.Logf("Verifying GSLBHostRule")
 	g.Expect(err).To(gomega.BeNil())
 	t.Logf("Verified GSLBHostRule")
@@ -96,7 +96,7 @@ func TestGSLBHostRuleInvalidSitePersistence(t *testing.T) {
 	gslbhrObj := getTestGSLBHRObject(gslbhrTestObjName, gslbhrTestNamespace, gslbhrTestFqdn)
 	gslbhrObj.Spec.SitePersistence = gslbhrsp
 	t.Logf("Adding GSLBHostRule with invalid Site Persistences Profiles")
-	err := gslbingestion.ValidateGSLBHostRule(gslbhrObj)
+	err := gslbingestion.ValidateGSLBHostRule(gslbhrObj, false)
 	t.Logf("Verifying GSLBHostRule")
 	g.Expect(err).NotTo(gomega.BeNil())
 	t.Logf("Verified GSLBHostRule")
@@ -108,7 +108,7 @@ func TestGSLBHostRuleValidHealthMonitors(t *testing.T) {
 	gslbhrObj := getTestGSLBHRObject(gslbhrTestObjName, gslbhrTestNamespace, gslbhrTestFqdn)
 	gslbhrObj.Spec.HealthMonitorRefs = gslbhrHealthMonitorRefs
 	t.Logf("Adding GSLBHostRule with Valid Health Monitor Refs")
-	err := gslbingestion.ValidateGSLBHostRule(gslbhrObj)
+	err := gslbingestion.ValidateGSLBHostRule(gslbhrObj, false)
 	t.Logf("Verifying GSLBHostRule")
 	g.Expect(err).To(gomega.BeNil())
 	t.Logf("Verified GSLBHostRule")
@@ -120,7 +120,7 @@ func TestGSLBHostRuleInvalidHealthMonitors(t *testing.T) {
 	gslbhrObj := getTestGSLBHRObject(gslbhrTestObjName, gslbhrTestNamespace, gslbhrTestFqdn)
 	gslbhrObj.Spec.HealthMonitorRefs = gslbhrHealthMonitorRefs
 	t.Logf("Adding GSLBHostRule with invalid Health Monitor Refs")
-	err := gslbingestion.ValidateGSLBHostRule(gslbhrObj)
+	err := gslbingestion.ValidateGSLBHostRule(gslbhrObj, false)
 	t.Logf("Verifying GSLBHostRule")
 	g.Expect(err).NotTo(gomega.BeNil())
 	t.Logf("Verified GSLBHostRule")

--- a/gslb/test/ingestion/lib.go
+++ b/gslb/test/ingestion/lib.go
@@ -300,7 +300,7 @@ func addGDPAndGSLBForIngress(t *testing.T) *gdpalphav2.GlobalDeploymentPolicy {
 
 	ingestionQ := containerutils.SharedWorkQueue().GetQueueByName(containerutils.ObjectIngestionLayer)
 	gdp := getTestGDPObject(true, false)
-	gslbingestion.AddGDPObj(gdp, ingestionQ.Workqueue, 2)
+	gslbingestion.AddGDPObj(gdp, ingestionQ.Workqueue, 2, false)
 
 	return gdp
 }

--- a/gslb/test/ingestion/services_test.go
+++ b/gslb/test/ingestion/services_test.go
@@ -38,7 +38,7 @@ const (
 func addGDPAndGSLBForSvc(t *testing.T) *gdpalphav2.GlobalDeploymentPolicy {
 	ingestionQ := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
 	gdp := getTestGDPObject(true, false)
-	gslbingestion.AddGDPObj(gdp, ingestionQ.Workqueue, 2)
+	gslbingestion.AddGDPObj(gdp, ingestionQ.Workqueue, 2, false)
 
 	gslbObj := getTestGSLBObject()
 	gc, err := gslbingestion.IsGSLBConfigValid(gslbObj)


### PR DESCRIPTION
During bootup today, AMKO tries to fetch the referred objects like
Health Monitor refs and Site Persistence Profile refs in `GDP` and
`GSLBHostRule` objects. However, repeated GET requests for these
objects is not desirable.

This fix creates a site persistence cache during bootup and leverages
the existing health monitor cache for such lookups. If the referred
object is not found, we mark the object as invalid (as before).
Non-bootup operations like `UPDATE` for `GDP` and `ADD/UPDATE` for
`GSLBHostRule` will still follow the pre-existing logic of fetching
the refs from the controller, so as to avoid stale entries.