### PR TITLE
Fix the GslbService group name before doing a REST Operation

### DIFF
--- a/gslb/rest/dq_nodes.go
+++ b/gslb/rest/dq_nodes.go
@@ -839,7 +839,7 @@ func (restOp *RestOperations) AviGSBuild(gsMeta *nodes.AviGSObjectGraph, restMet
 	}
 	// Now, build a GSLB pool
 	poolEnabled := true
-	poolName := gsMeta.Name + "-10"
+	poolName := "amko-gs-group"
 	priority := int32(10)
 	minHealthMonUp := int32(2)
 	poolAlgorithm, hashMask, fallback := restOp.getGSPoolAlgorithmSettings(gsMeta)


### PR DESCRIPTION
Currently, we name the GslbService group name as `host_fqdn-10`. This
causes an issue in the Avi Controller because of the group name
limitation in the controller. This patch shortens the name to
`amko-gs-group`. Since, this name isn't used anywhere else in AMKO,
no other changes are required.

Note that the existing GSLB Services will continue to have the same
naming convention as `host_fqdn-10`, unless the user updates the
underlying ingress/route members which will force AMKO to update the
GS with a new group name. The update doesn't hamper the traffic flow.