### PR TITLE
Retry support for ingestion layer

### DIFF
--- a/gslb/gslbutils/constants.go
+++ b/gslb/gslbutils/constants.go
@@ -40,6 +40,7 @@ const (
 	PassthroughRoute     = "passthrough"
 	ThirdPartyMemberType = "ThirdPartyMember"
 	HostRuleType         = "HostRule"
+	GslbHostRuleType     = "GSLBHostRule"
 
 	// Refresh cycle for AVI cache in seconds
 	DefaultRefreshInterval = 600
@@ -54,10 +55,11 @@ const (
 	GSFQDNKeyLen          = 3
 
 	// Default values for Retry Operations
-	SlowSyncTime      = 120
-	SlowRetryQueue    = "SlowRetry"
-	FastRetryQueue    = "FastRetry"
-	DefaultRetryCount = 5
+	SlowSyncTime        = 120
+	SlowRetryQueue      = "SlowRetry"
+	FastRetryQueue      = "FastRetry"
+	IngestionRetryQueue = "IngestionRetry"
+	DefaultRetryCount   = 5
 
 	// Identify objects created by AMKO
 	AmkoUser = "amko-gslb"

--- a/gslb/gslbutils/errors.go
+++ b/gslb/gslbutils/errors.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package gslbutils
+
+// Error codes
+const (
+	ObjectErrStatus     = 1
+	ControllerErrStatus = 2
+	ResponseParseStatus = 3
+	FederatedErrStatus  = 4
+)
+
+type ControllerValidationError struct {
+	errCode int
+	msg     string
+}
+
+func (vErr ControllerValidationError) Error() string {
+	if vErr.errCode < 5 && vErr.errCode > 0 {
+		return vErr.msg
+	}
+	return "unknown status code"
+}
+
+func GetIngestionErrorForObjectNotFound(errMsg string) error {
+	return ControllerValidationError{errCode: ObjectErrStatus, msg: errMsg}
+}
+
+func GetIngestionErrorForController(errMsg string) error {
+	return ControllerValidationError{errCode: ControllerErrStatus, msg: errMsg}
+}
+
+func GetIngestionErrorForParsing(errMsg string) error {
+	return ControllerValidationError{errCode: ResponseParseStatus, msg: errMsg}
+}
+
+func GetIngestionErrorForObjectNotFederated(errMsg string) error {
+	return ControllerValidationError{errCode: FederatedErrStatus, msg: errMsg}
+}
+
+// IsControllerError returns true only if there was an issue in communicating with the controller.
+func IsControllerError(err error) bool {
+	vErr, ok := err.(ControllerValidationError)
+	if !ok || vErr.errCode != ControllerErrStatus {
+		return false
+	}
+	return true
+}
+
+// IsRetriableOnError returns true only if a retry is required
+func IsRetriableOnError(err error) bool {
+	// For errors other than object not federated, we will retry for everything else
+	vErr, ok := err.(ControllerValidationError)
+	if !ok {
+		return false
+	}
+	if vErr.errCode == FederatedErrStatus {
+		return false
+	}
+	return true
+}

--- a/gslb/ingestion/fullsync.go
+++ b/gslb/ingestion/fullsync.go
@@ -145,6 +145,10 @@ func checkGslbHostRulesAndInitialize() error {
 		if err != nil {
 			updateGSLBHR(&gslbHr, err.Error(), GslbHostRuleRejected)
 			gslbutils.Errf("Error in accepting GSLB Host Rule %s : %v", gsFqdn, err)
+			if gslbutils.IsRetriableOnError(err) {
+				updateIngestionRetryAddCache(&gslbHr)
+				publishKeyToIngestionRetry(gslbutils.ObjectAdd, gslbutils.GslbHostRuleType, gslbHr.Namespace, gslbHr.Name)
+			}
 			continue
 		}
 		gsFqdnHostRule := gsHostRulesList.GetGSHostRulesForFQDN(gsFqdn)

--- a/gslb/ingestion/gdp_controller.go
+++ b/gslb/ingestion/gdp_controller.go
@@ -324,8 +324,9 @@ func GDPSanityChecks(gdp *gdpalphav2.GlobalDeploymentPolicy, fullSync bool) erro
 	// Health monotor validity
 	if len(gdp.Spec.HealthMonitorRefs) != 0 {
 		for _, hmRef := range gdp.Spec.HealthMonitorRefs {
-			if !isHealthMonitorRefValid(hmRef, true, fullSync) {
-				return fmt.Errorf("health monitor ref %s is invalid", hmRef)
+			err := isHealthMonitorRefValid(hmRef, true, fullSync)
+			if err != nil {
+				return fmt.Errorf("health monitor ref %s is invalid: %s", hmRef, err.Error())
 			}
 		}
 	}
@@ -339,8 +340,9 @@ func GDPSanityChecks(gdp *gdpalphav2.GlobalDeploymentPolicy, fullSync bool) erro
 	if gdp.Spec.SitePersistenceRef != nil && *gdp.Spec.SitePersistenceRef == "" {
 		return fmt.Errorf("empty string as site persistence reference not supported")
 	} else if gdp.Spec.SitePersistenceRef != nil {
-		if !isSitePersistenceProfilePresent(*gdp.Spec.SitePersistenceRef, true, fullSync) {
-			return fmt.Errorf("site persistence ref %s not present", *gdp.Spec.SitePersistenceRef)
+		err := isSitePersistenceProfilePresent(*gdp.Spec.SitePersistenceRef, true, fullSync)
+		if err != nil {
+			return fmt.Errorf("site persistence ref %s is invalid: %s", *gdp.Spec.SitePersistenceRef, err.Error())
 		}
 	}
 	return nil

--- a/gslb/ingestion/gslb.go
+++ b/gslb/ingestion/gslb.go
@@ -680,8 +680,14 @@ func Initialize() {
 	graphQueueParams := utils.WorkerQueue{NumWorkers: gslbutils.NumRestWorkers, WorkqueueName: utils.GraphLayer}
 	slowRetryQParams := utils.WorkerQueue{NumWorkers: 1, WorkqueueName: gslbutils.SlowRetryQueue, SlowSyncTime: gslbutils.SlowSyncTime}
 	fastRetryQParams := utils.WorkerQueue{NumWorkers: 1, WorkqueueName: gslbutils.FastRetryQueue}
+	ingestionRetryQParams := utils.WorkerQueue{NumWorkers: 1, WorkqueueName: gslbutils.IngestionRetryQueue, SlowSyncTime: gslbutils.SlowSyncTime}
 
-	utils.SharedWorkQueue(&ingestionQueueParams, &graphQueueParams, &slowRetryQParams, &fastRetryQParams)
+	utils.SharedWorkQueue(&ingestionQueueParams, &graphQueueParams, &slowRetryQParams, &fastRetryQParams, &ingestionRetryQParams)
+
+	// Set workers for ingestion queue retry workers
+	ingestionRetryQueue := utils.SharedWorkQueue().GetQueueByName(gslbutils.IngestionRetryQueue)
+	ingestionRetryQueue.SyncFunc = IngestionRetryAddUpdate
+	ingestionRetryQueue.Run(stopCh, gslbutils.GetWaitGroupFromMap(gslbutils.WGIngestionRetry))
 
 	// Set workers for layer 3 (REST layer)
 	graphSharedQueue := utils.SharedWorkQueue().GetQueueByName(utils.GraphLayer)

--- a/gslb/ingestion/ingestion_retry.go
+++ b/gslb/ingestion/ingestion_retry.go
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package ingestion
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/gslbutils"
+	gslbhralphav1 "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/apis/amko/v1alpha1"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type retryUpdateValues struct {
+	old *gslbhralphav1.GSLBHostRule
+	new *gslbhralphav1.GSLBHostRule
+}
+
+type retryUpdateCache struct {
+	cache map[string]retryUpdateValues
+	lock  sync.RWMutex
+}
+
+var retryUpdateMap *retryUpdateCache
+var retryUpdateOnce sync.Once
+
+func getRetryUpdateCache() *retryUpdateCache {
+	retryUpdateOnce.Do(func() {
+		retryUpdateMap = &retryUpdateCache{
+			cache: map[string]retryUpdateValues{},
+		}
+	})
+	return retryUpdateMap
+}
+
+func (c *retryUpdateCache) writeValueFor(ns, name string, old, new *gslbhralphav1.GSLBHostRule) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	key := ns + "/" + name
+	val, ok := c.cache[ns+"/"+name]
+	if !ok {
+		// value doesn't exist, just write and return
+		c.cache[key] = retryUpdateValues{
+			old: old,
+			new: new,
+		}
+		return
+	}
+	// value exists, just update the new value
+	c.cache[key] = retryUpdateValues{
+		old: val.old,
+		new: new,
+	}
+}
+
+func (c *retryUpdateCache) readAndDeleteKeyFor(ns, name string) (retryUpdateValues, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	val, ok := c.cache[ns+"/"+name]
+	if !ok {
+		return retryUpdateValues{}, fmt.Errorf("value not present for namespace %s and name %s", ns, name)
+	}
+	delete(c.cache, ns+"/"+name)
+	return val, nil
+}
+
+type retryAddCache struct {
+	cache map[string]*gslbhralphav1.GSLBHostRule
+	lock  sync.RWMutex
+}
+
+var retryAddMap *retryAddCache
+var retryAddOnce sync.Once
+
+func getRetryAddCache() *retryAddCache {
+	retryAddOnce.Do(func() {
+		retryAddMap = &retryAddCache{
+			cache: map[string]*gslbhralphav1.GSLBHostRule{},
+		}
+	})
+	return retryAddMap
+}
+
+func (c *retryAddCache) writeValueFor(ns, name string, obj *gslbhralphav1.GSLBHostRule) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.cache[ns+"/"+name] = obj
+}
+
+func (c *retryAddCache) readAndDeleteKeyFor(ns, name string) (*gslbhralphav1.GSLBHostRule, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	val, ok := c.cache[ns+"/"+name]
+	if !ok {
+		return nil, fmt.Errorf("value not present for namespace %s and name %s", ns, name)
+	}
+	delete(c.cache, ns+"/"+name)
+	return val, nil
+}
+
+func publishKeyToIngestionRetry(op, obj, namespace, name string) {
+	key := op + "/" + obj + "/" + namespace + "/" + name
+	rq := utils.SharedWorkQueue().GetQueueByName(gslbutils.IngestionRetryQueue)
+	rq.Workqueue[0].AddRateLimited(key)
+	gslbutils.Logf("key: %s, msg: published key to ingestion retry queue", key)
+}
+
+func updateIngestionRetryAddCache(obj *gslbhralphav1.GSLBHostRule) {
+	if obj == nil {
+		return
+	}
+	gslbhr := obj.DeepCopy()
+	addCache := getRetryAddCache()
+	addCache.writeValueFor(gslbhr.Namespace, gslbhr.Name, gslbhr)
+}
+
+func updateIngestionRetryUpdateCache(oldObj, newObj *gslbhralphav1.GSLBHostRule) {
+	if oldObj == nil || newObj == nil {
+		return
+	}
+	old, new := oldObj.DeepCopy(), newObj.DeepCopy()
+	updateCache := getRetryUpdateCache()
+	updateCache.writeValueFor(new.Namespace, new.Name, old, new)
+}
+
+func getGslbHostRule(ns, name string) (*gslbhralphav1.GSLBHostRule, error) {
+	obj, err := gslbutils.GlobalGslbClient.AmkoV1alpha1().GSLBHostRules(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func IngestionRetryAddUpdate(key string, wg *sync.WaitGroup) error {
+	gslbutils.Logf("key: %s, msg: processing key in ingestion retry", key)
+	op, objType, ns, name, err := gslbutils.ExtractIngestionRetryQueueKey(key)
+	if err != nil {
+		gslbutils.Errf("key: %s, msg: error in processing key for ingestion retry: %v", key, err)
+		return nil
+	}
+
+	k8sQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
+	switch objType {
+	case gslbutils.GslbHostRuleType:
+		ghrObj, err := getGslbHostRule(ns, name)
+		if err != nil {
+			gslbutils.Errf("key: %s, msg: error in getting GSLBHostRule object: %v", key, err)
+			return nil
+		}
+
+		switch op {
+		case gslbutils.ObjectAdd:
+			addCache := getRetryAddCache()
+			addObj, err := addCache.readAndDeleteKeyFor(ns, name)
+			if err != nil {
+				gslbutils.Errf("key: %s, ns: %s, name: %s, msg: object not present in retry add cache",
+					key, ns, name)
+				return nil
+			}
+			if ghrObj.ResourceVersion > addObj.ResourceVersion {
+				// a new resource version is available, no point in retrying for the old object
+				gslbutils.Logf("key: %s, ns: %s, name %s, msg: an object with new resource version available, won't retry",
+					key, ns, name)
+				return nil
+			}
+			gslbutils.Logf("key: %s, ns: %s, name: %s, msg: will retry adding object", key, ns, name)
+			AddGSLBHostRuleObj(addObj, k8sQueue.Workqueue, k8sQueue.NumWorkers)
+			return nil
+
+		case gslbutils.ObjectUpdate:
+			updateCache := getRetryUpdateCache()
+			updateObjs, err := updateCache.readAndDeleteKeyFor(ns, name)
+			if err != nil {
+				gslbutils.Errf("key: %s, ns: %s, name: %s, msg: objects not present in the update cache",
+					key, ns, name)
+				return nil
+			}
+			UpdateGSLBHostRuleObj(updateObjs.old, updateObjs.new, k8sQueue.Workqueue, k8sQueue.NumWorkers)
+			return nil
+		}
+
+	default:
+		gslbutils.Errf("key: %s, msg: unsupported object in ingestion retry worker", key)
+	}
+	return nil
+}


### PR DESCRIPTION
Fixes AV-113235
Currently, if AMKO is unable to reach the controller because of a network
issue while validating the references in a `GSLBHostRule`, it doesn't
retry or reconcile even after the network issue is fixed. A reconcilation
may also be required if the user provides a non-existent reference, but
the user creates the reference later.

This PR introduces a retry queue for the ingestion layer. Currently, it
will only be used for `GSLBHostRule` objects. It functions like the slow
retry queue, but at the end of the tiner expiry, it makes a decision
to call add/update the `GSLBHostRule` based on the key that's pushed.

Decision to retry: A retry decision is made for all cases for an object
reference check, except for non-federated objects.