### PR TITLE
Handle member clusters connectivity problem during boot up

### DIFF
--- a/gslb/gslbutils/constants.go
+++ b/gslb/gslbutils/constants.go
@@ -44,6 +44,9 @@ const (
 	// Refresh cycle for AVI cache in seconds
 	DefaultRefreshInterval = 600
 
+	// Refresh cycle for member clusters in seconds
+	DefaultClusterConnectInterval = 30
+
 	// Store types
 	AcceptedStore = "Accepted"
 	RejectedStore = "Rejected"

--- a/gslb/gslbutils/gslbutils.go
+++ b/gslb/gslbutils/gslbutils.go
@@ -391,17 +391,17 @@ func GetAviConfig() AviControllerConfig {
 	return gslbLeaderConfig
 }
 
-var initializedClusterContexts []string
+var allClusterContexts []string
 
 func AddClusterContext(cc string) {
 	if IsClusterContextPresent(cc) {
 		return
 	}
-	initializedClusterContexts = append(initializedClusterContexts, cc)
+	allClusterContexts = append(allClusterContexts, cc)
 }
 
 func IsClusterContextPresent(cc string) bool {
-	for _, context := range initializedClusterContexts {
+	for _, context := range allClusterContexts {
 		if context == cc {
 			return true
 		}

--- a/gslb/ingestion/fullsync.go
+++ b/gslb/ingestion/fullsync.go
@@ -219,9 +219,8 @@ func resyncMemberCluster() {
 			gslbutils.Warnf("cluster: %s, msg: %s, %s", cluster.clusterName, "error in connecting to kubernetes API",
 				err)
 			continue
-		} else {
-			gslbutils.Logf("cluster: %s, msg: %s", cluster.clusterName, "successfully connected to kubernetes API")
 		}
+		gslbutils.Logf("cluster: %s, msg: %s", cluster.clusterName, "successfully connected to kubernetes API")
 		aviCtrl, err := InitializeMemberCluster(cfg, cluster, clients)
 		if err != nil {
 			gslbutils.Warnf("error initializing member cluster %s: %s", cluster.clusterName, err)

--- a/gslb/ingestion/gslb.go
+++ b/gslb/ingestion/gslb.go
@@ -64,6 +64,8 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 )
 
+var pendingClusters map[KubeClusterDetails]bool
+
 const (
 	BootupMsg              = "starting up amko"
 	BootupSyncMsg          = "syncing all objects"
@@ -593,6 +595,12 @@ func AddGSLBConfigObject(obj interface{}, initializeGSLBMemberClusters Initializ
 	resyncNodesWorker.SyncFunction = ResyncNodesToRestLayer
 	go resyncNodesWorker.Run()
 
+	// Initialize a periodic worker to sync member clusters which failed to connect during initial bootup
+	// To Do: make this customisable through a field in gslb config
+	resyncMemberWorker := gslbutils.NewFullSyncThread(time.Duration(gslbutils.DefaultClusterConnectInterval))
+	resyncMemberWorker.SyncFunction = resyncMemberCluster
+	go resyncMemberWorker.Run()
+
 	gcChan := gslbutils.GetGSLBConfigObjectChan()
 	*gcChan <- true
 
@@ -831,7 +839,6 @@ func InitializeMemberCluster(cfg *restclient.Config, cluster KubeClusterDetails,
 		aviCtrl = GetGSLBMemberController(cluster.clusterName, informerInstance, nil)
 	}
 
-	gslbutils.AddClusterContext(cluster.clusterName)
 	aviCtrl.SetupEventHandlers(K8SInformers{Cs: clients[cluster.clusterName]})
 	return &aviCtrl, nil
 }
@@ -842,8 +849,11 @@ func InitializeGSLBMemberClusters(membersKubeConfig string, memberClusters []gsl
 	clients := make(map[string]*kubernetes.Clientset)
 
 	aviCtrlList := make([]*GSLBMemberController, 0)
+	pendingClusters = make(map[KubeClusterDetails]bool)
 	for _, cluster := range clusterDetails {
 		gslbutils.Logf("cluster: %s, msg: %s", cluster.clusterName, "initializing")
+		gslbutils.AddClusterContext(cluster.clusterName)
+
 		cfg, err := BuildContextConfig(cluster.kubeconfig, cluster.clusterName)
 		if err != nil {
 			gslbutils.Warnf("cluster: %s, msg: %s, %s", cluster.clusterName, "error in connecting to kubernetes API",
@@ -854,7 +864,9 @@ func InitializeGSLBMemberClusters(membersKubeConfig string, memberClusters []gsl
 		}
 		aviCtrl, err := InitializeMemberCluster(cfg, cluster, clients)
 		if err != nil {
-			return nil, fmt.Errorf("error initializing member cluster %s: %s", cluster.clusterName, err)
+			gslbutils.Warnf("error initializing member cluster %s: %s", cluster.clusterName, err)
+			pendingClusters[cluster] = true
+			continue
 		}
 		if aviCtrl != nil {
 			aviCtrlList = append(aviCtrlList, aviCtrl)

--- a/gslb/test/integration/custom_fqdn/custom_fqdn_test.go
+++ b/gslb/test/integration/custom_fqdn/custom_fqdn_test.go
@@ -256,6 +256,7 @@ func GetTestEnvClustersAsGslbMembers(arg1 string, arg2 []gslbalphav1.MemberClust
 
 	memberClusterList := make([]*ingestion.GSLBMemberController, 0)
 	for idx, c := range testClustersContexts {
+		gslbutils.AddClusterContext(c.GetClusterContextName())
 		member, err := ingestion.InitializeMemberCluster(cfgs[idx], c, clients)
 		if err != nil {
 			return nil, err

--- a/gslb/test/integration/third_party_vips/int_test.go
+++ b/gslb/test/integration/third_party_vips/int_test.go
@@ -258,6 +258,7 @@ func GetTestEnvClustersAsGslbMembers(arg1 string, arg2 []gslbalphav1.MemberClust
 
 	memberClusterList := make([]*ingestion.GSLBMemberController, 0)
 	for idx, c := range testClustersContexts {
+		gslbutils.AddClusterContext(c.GetClusterContextName())
 		member, err := ingestion.InitializeMemberCluster(cfgs[idx], c, clients)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Currently, if any member cluster is not reachable when AMKO is booting up,
AMKO throws an error and shuts down.

As part of the change, this boot up condition is removed. Cluster contexts from
gslb config objects are being stored irrespective of their reachability and
initialisation status. This ensures that GDB objects can vaidate against cluster
names which are not avialable during boot up.

In addition, periodically AMKO would check if any unavialable member cluster becomes
reachable again. Once the connectivity is restored, all relevant k8s objects
would be processed and corresponding AVI objects would be updated.