### PR TITLE
AMKO bootup checks to ensure that the current instance is the only leader

### DIFF
--- a/federator/controllers/amkocluster_controller.go
+++ b/federator/controllers/amkocluster_controller.go
@@ -293,6 +293,6 @@ func (r *AMKOClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			}),
 		).
 		For(&amkov1alpha1.AMKOCluster{}).
-		WithEventFilter(acceptGenerationChangePredicate()).
+		WithEventFilter(AcceptGenerationChangePredicate()).
 		Complete(r)
 }

--- a/federator/controllers/amkocluster_controller.go
+++ b/federator/controllers/amkocluster_controller.go
@@ -110,7 +110,7 @@ func (r *AMKOClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	// fetch the member clusters' contexts
-	memberClusters, err := r.FetchMemberClusterContexts(ctx, amkoCluster.DeepCopy())
+	memberClusters, err := FetchMemberClusterContexts(ctx, amkoCluster.DeepCopy())
 	if err != nil {
 		statusErr := r.UpdateAMKOClusterStatus(ctx, FederationTypeStatus, StatusMsgFederationFailure, err.Error(), &amkoCluster)
 		if statusErr != nil {
@@ -122,7 +122,7 @@ func (r *AMKOClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	// validate member clusters
-	err = r.ValidateMemberClusters(ctx, memberClusters)
+	err = ValidateMemberClusters(ctx, memberClusters)
 	if err != nil {
 		statusErr := r.UpdateAMKOClusterStatus(ctx, FederationTypeStatus, StatusMsgFederationFailure, err.Error(), &amkoCluster)
 		if statusErr != nil {
@@ -205,82 +205,6 @@ func (r *AMKOClusterReconciler) GetObjectsToBeFederated(ctx context.Context) ([]
 	objList = append(objList, gdpObj)
 
 	return objList, nil
-}
-
-func (r *AMKOClusterReconciler) ValidateMemberClusters(ctx context.Context, memberClusters []KubeContextDetails) error {
-	// Perform validation checks
-	// 1. Only one instance of AMKOCluster must be present in the avi-system namespace
-	// 2. No other cluster should be leader if the current instance is leader
-	// 3. No version mismatch
-	for _, cluster := range memberClusters {
-		if cluster.client == nil {
-			log.Log.Info("client is nil", "cluster", cluster.clusterName)
-			return fmt.Errorf("cluster client unavailable for cluster %s", cluster.clusterName)
-		}
-		clusterClient := *(cluster.client)
-		var amkoCluster amkov1alpha1.AMKOClusterList
-		err := clusterClient.List(ctx, &amkoCluster)
-		if err != nil {
-			return fmt.Errorf("error in getting AMKOCluster list for cluster %s: %v",
-				cluster.clusterName, err)
-		}
-
-		if len(amkoCluster.Items) > 1 {
-			return fmt.Errorf("more than one AMKOCluster objects present in cluster %s, can't federate",
-				cluster.clusterName)
-		}
-
-		obj := amkoCluster.Items[0].DeepCopy()
-		if obj.Namespace != AviSystemNS {
-			return fmt.Errorf("AMKOCluster object not present in avi-system namespace in cluster %s, can't federate",
-				cluster.clusterName)
-		}
-
-		if obj.Spec.IsLeader {
-			return fmt.Errorf("AMKO in cluster %s is also a leader, conflicting state", cluster.clusterName)
-		}
-	}
-
-	return nil
-}
-
-func (r *AMKOClusterReconciler) FetchMemberClusterContexts(ctx context.Context, amkoCluster *amkov1alpha1.AMKOCluster) ([]KubeContextDetails, error) {
-	err := generateTempKubeConfig()
-	if err != nil {
-		return nil, err
-	}
-	memberClusters, err := r.InitMemberClusterContexts(ctx, amkoCluster.Spec.ClusterContext, amkoCluster.Spec.Clusters)
-	if err != nil {
-		return nil, fmt.Errorf("error in initializing member cluster contexts: %v", err)
-	}
-
-	return memberClusters, nil
-}
-
-func (r *AMKOClusterReconciler) InitMemberClusterContexts(ctx context.Context, currentContext string, clusterList []string) ([]KubeContextDetails, error) {
-	// - obtain the list of all member cluster contexts from the kubeconfig
-	// - remove the current context
-	// - build the context config for the rest of them
-	memberClusters := getClusterContextDetails(MembersKubePath, clusterList, currentContext)
-
-	for idx, cluster := range memberClusters {
-		if currentContext == cluster.clusterName {
-			// skip for current context
-			continue
-		}
-		log.Log.Info("initializing cluster context", "cluster", cluster.clusterName)
-		cfg, err := BuildContextConfig(cluster.kubeconfig, cluster.clusterName)
-		if err != nil {
-			return nil, fmt.Errorf("error in building context config for kubernetes cluster %s: %v",
-				cluster.clusterName, err)
-		}
-		client, err := InitializeMemberClusterClient(cfg)
-		if err != nil {
-			return nil, fmt.Errorf("error in initializing member custer context %s: %v", cluster.clusterName, err)
-		}
-		memberClusters[idx].client = &client
-	}
-	return memberClusters, nil
 }
 
 func (r *AMKOClusterReconciler) VerifyAMKOClusterSanity(amkoCluster *amkov1alpha1.AMKOCluster) error {

--- a/federator/controllers/utils.go
+++ b/federator/controllers/utils.go
@@ -208,7 +208,7 @@ func generateTempKubeConfig() error {
 	return nil
 }
 
-func acceptGenerationChangePredicate() predicate.Predicate {
+func AcceptGenerationChangePredicate() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			e.ObjectOld.GetGeneration()

--- a/federator/controllers/utils.go
+++ b/federator/controllers/utils.go
@@ -225,3 +225,81 @@ func getStatusCondition(statusType, statusMsg, reason string) amkov1alpha1.AMKOC
 		Reason: reason,
 	}
 }
+
+// To Do: Move functions used by both federator and main gslb to a common library
+func ValidateMemberClusters(ctx context.Context, memberClusters []KubeContextDetails) error {
+	// Perform validation checks
+	// 1. Only one instance of AMKOCluster must be present in the avi-system namespace
+	// 2. No other cluster should be leader if the current instance is leader
+	// 3. No version mismatch
+	for _, cluster := range memberClusters {
+		if cluster.client == nil {
+			log.Log.Info("client is nil", "cluster", cluster.clusterName)
+			return fmt.Errorf("cluster client unavailable for cluster %s", cluster.clusterName)
+		}
+		clusterClient := *(cluster.client)
+		var amkoCluster amkov1alpha1.AMKOClusterList
+		err := clusterClient.List(ctx, &amkoCluster)
+		if err != nil {
+			return fmt.Errorf("error in getting AMKOCluster list for cluster %s: %v",
+				cluster.clusterName, err)
+		}
+
+		if len(amkoCluster.Items) > 1 {
+			return fmt.Errorf("more than one AMKOCluster objects present in cluster %s, can't federate",
+				cluster.clusterName)
+		}
+
+		obj := amkoCluster.Items[0].DeepCopy()
+		if obj.Namespace != AviSystemNS {
+			return fmt.Errorf("AMKOCluster object not present in avi-system namespace in cluster %s, can't federate",
+				cluster.clusterName)
+		}
+
+		if obj.Spec.IsLeader {
+			return fmt.Errorf("AMKO in cluster %s is also a leader, conflicting state", cluster.clusterName)
+		}
+	}
+
+	return nil
+}
+
+func FetchMemberClusterContexts(ctx context.Context, amkoCluster *amkov1alpha1.AMKOCluster) ([]KubeContextDetails, error) {
+	err := generateTempKubeConfig()
+	if err != nil {
+		return nil, err
+	}
+	memberClusters, err := InitMemberClusterContexts(ctx, amkoCluster.Spec.ClusterContext, amkoCluster.Spec.Clusters)
+	if err != nil {
+		return nil, fmt.Errorf("error in initializing member cluster contexts: %v", err)
+	}
+
+	return memberClusters, nil
+}
+
+func InitMemberClusterContexts(ctx context.Context, currentContext string, clusterList []string) ([]KubeContextDetails, error) {
+	// - obtain the list of all member cluster contexts from the kubeconfig
+	// - remove the current context
+	// - build the context config for the rest of them
+	memberClusters := getClusterContextDetails(MembersKubePath, clusterList, currentContext)
+
+	for idx, cluster := range memberClusters {
+		if currentContext == cluster.clusterName {
+			// skip for current context
+			continue
+		}
+		log.Log.Info("initializing cluster context", "cluster", cluster.clusterName)
+		cfg, err := BuildContextConfig(cluster.kubeconfig, cluster.clusterName)
+		if err != nil {
+			return nil, fmt.Errorf("error in building context config for kubernetes cluster %s: %v",
+				cluster.clusterName, err)
+		}
+		client, err := InitializeMemberClusterClient(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("error in initializing member custer context %s: %v", cluster.clusterName, err)
+		}
+
+		memberClusters[idx].client = &client
+	}
+	return memberClusters, nil
+}

--- a/gslb/ingestion/bootup_handler.go
+++ b/gslb/ingestion/bootup_handler.go
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package ingestion
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	amkov1alpha1 "github.com/vmware/global-load-balancing-services-for-kubernetes/federator/api/v1alpha1"
+	federator "github.com/vmware/global-load-balancing-services-for-kubernetes/federator/controllers"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/apiserver"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/gslbutils"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	restclient "k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var clusterScheme *k8sruntime.Scheme
+
+const (
+	metricsAddr   = ":8081"
+	apiServerPort = 9453
+)
+
+func InitializeClusterClient(cfg *restclient.Config) (client.Client, error) {
+	clusterScheme = k8sruntime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(clusterScheme))
+	utilruntime.Must(amkov1alpha1.AddToScheme(clusterScheme))
+
+	c, err := client.New(cfg, client.Options{
+		Scheme: clusterScheme,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error in getting client: %v", err)
+	}
+
+	return c, nil
+}
+
+type AMKOClusterReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+func createController() {
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:             clusterScheme,
+		MetricsBindAddress: metricsAddr,
+		Port:               apiServerPort,
+	})
+	if err != nil {
+		gslbutils.Errf("unable to start manager: %v", err)
+		os.Exit(1)
+	}
+
+	if err = (&AMKOClusterReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		gslbutils.Errf("unable to create cluster reconciler: %v", err)
+		os.Exit(1)
+	}
+	go func() {
+		if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+			gslbutils.Errf("problem starting manager: %v", err)
+			os.Exit(1)
+		}
+	}()
+}
+
+var currentLeader bool
+
+func acceptGenerationChangePredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			e.ObjectOld.GetGeneration()
+			// skip if no generation change, applicable to all objects
+			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
+		},
+	}
+}
+
+func (r *AMKOClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	gslbutils.Debugf("Starting AMKOCluster reconcialation")
+
+	var amkoClusterList amkov1alpha1.AMKOClusterList
+	err := r.List(ctx, &amkoClusterList, &client.ListOptions{
+		Namespace: federator.AviSystemNS,
+	})
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("AMKOClusterObjects can't be listed, err: %v", err)
+	}
+	if len(amkoClusterList.Items) > 1 {
+		return reconcile.Result{}, fmt.Errorf("only one AMKOClusterObject allowed per cluster")
+	}
+
+	amkoCluster := amkoClusterList.Items[0]
+	if currentLeader != amkoCluster.Spec.IsLeader {
+		gslbutils.Warnf("AMKO leader flag changed, API server would be shut down")
+		apiserver.GetAmkoAPIServer().ShutDown()
+		return ctrl.Result{}, nil
+	}
+
+	currentLeader = amkoCluster.Spec.IsLeader
+	if !currentLeader {
+		gslbutils.Warnf("AMKO is not a leader, will return")
+		return ctrl.Result{}, nil
+	}
+
+	memberClusters, err := federator.FetchMemberClusterContexts(ctx, amkoCluster.DeepCopy())
+	gslbutils.Debugf("memberClusters obtained during reconcialation: %v", memberClusters)
+
+	err = federator.ValidateMemberClusters(ctx, memberClusters)
+	if err != nil {
+		apiserver.GetAmkoAPIServer().ShutDown()
+		return reconcile.Result{}, fmt.Errorf("error in validating the member clusters: %v", err)
+	}
+
+	gslbutils.Debugf("AMKOCluster reconcialation completed")
+	return ctrl.Result{}, nil
+}
+
+func (r *AMKOClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Watches(&source.Kind{Type: &amkov1alpha1.AMKOCluster{}},
+			handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request {
+				return []reconcile.Request{
+					{
+						NamespacedName: types.NamespacedName{
+							Name:      o.GetName(),
+							Namespace: o.GetNamespace(),
+						},
+					},
+				}
+			}),
+		).
+		For(&amkov1alpha1.AMKOCluster{}).
+		WithEventFilter(acceptGenerationChangePredicate()).
+		Complete(r)
+}
+
+func handleBootup(cfg *restclient.Config) (bool, error) {
+	clusterClient, _ := InitializeClusterClient(cfg)
+	var amkoClusterList amkov1alpha1.AMKOClusterList
+	clusterClient.List(context.TODO(), &amkoClusterList, &client.ListOptions{
+		Namespace: federator.AviSystemNS,
+	})
+
+	if len(amkoClusterList.Items) == 0 {
+		gslbutils.Logf("No AMKOCluster object found, AMKO would start as leader")
+		return true, nil
+	}
+	if len(amkoClusterList.Items) > 1 {
+		return false, fmt.Errorf("only one AMKOClusterObject allowed per cluster")
+	}
+
+	amkoCluster := amkoClusterList.Items[0]
+	if amkoCluster.Spec.IsLeader {
+		currentLeader = true
+		gslbutils.Logf("AMKOCluster object found and AMKO would start as leader")
+	} else {
+		gslbutils.Logf("AMKOCluster object found and AMKO would start as follower")
+	}
+
+	memberClusters, err := federator.FetchMemberClusterContexts(context.TODO(), amkoCluster.DeepCopy())
+	gslbutils.Logf("memberClusters list found from amkoCluster object: %v", memberClusters)
+
+	err = federator.ValidateMemberClusters(context.TODO(), memberClusters)
+	if err != nil {
+		return false, fmt.Errorf("error in validating the member clusters: %v", err)
+	}
+	createController()
+	return currentLeader, nil
+}

--- a/gslb/ingestion/gslb.go
+++ b/gslb/ingestion/gslb.go
@@ -662,6 +662,17 @@ func Initialize() {
 		panic("error building kubernetes clientset: " + err.Error())
 	}
 
+	// handleBootup checks AMKOCluster object, validates and then starts a reconciler to process updates.
+	isLeader, err := handleBootup(cfg)
+	if err != nil {
+		panic("error during boot up: " + err.Error())
+	}
+	// If the current cluster is not the leader then don't progress and wait forever
+	if !isLeader {
+		<-stopCh
+		return
+	}
+
 	gslbutils.SetWaitGroupMap()
 	gslbutils.GlobalKubeClient = kubeClient
 	gslbClient, err := gslbcs.NewForConfig(cfg)


### PR DESCRIPTION
With introduction of AMKOCluster CRD, we need to check if isleader flag is set to true
when AMKO boots up. If the flag is set to true AMKO would check if any other cluster
is also running as leader, else proceed with normal operation.
If isleader flag is set to false, AMKO would not process any kubernetes objects except
listening to AMKOCluster object.

Whenever isLeader flag isLeader is changed, the API server would be shut down, triggering
a reboot of AMKO.