### PR TITLE
Fix the conflict with metrics address port

### DIFF
--- a/federator/main.go
+++ b/federator/main.go
@@ -56,8 +56,8 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":9091", "The address the metric endpoint binds to.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":9092", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")


### PR DESCRIPTION
The controller-runtime starts the metrics server in the default
port of 8080 (if a port number is not provided). This has a conflict
with the api server in AMKO. This PR fixes that conflict.

This also adds a fix to send the current AMKO version instead of
the current cluster to the validation function.