### PR TITLE
Federator should consolidate all GSLBConfigs and GDPs on member clusters

### DIFF
--- a/federator/controllers/amkocluster_controller.go
+++ b/federator/controllers/amkocluster_controller.go
@@ -155,7 +155,6 @@ func (r *AMKOClusterReconciler) FetchMemberClusterContextsAndUpdateStatus(ctx co
 		}
 	}
 
-	// if memberClusters list is empty, clear the rest of the status fields and return
 	if len(memberClusters) == 0 {
 		return nil, fmt.Errorf("no valid cluster contexts found")
 	}
@@ -419,9 +418,6 @@ func (r *AMKOClusterReconciler) UpdateAMKOClusterStatus(ctx context.Context, sta
 
 	// no such condition with status type, add a new one
 	updatedAMKOCluster.Status.Conditions = append(updatedAMKOCluster.Status.Conditions, condition)
-
-	tmpObj := amkov1alpha1.AMKOCluster{}
-	r.Get(ctx, types.NamespacedName{Name: tmpObj.Name, Namespace: tmpObj.Namespace}, &tmpObj)
 	return nil
 }
 

--- a/federator/controllers/amkocluster_controller.go
+++ b/federator/controllers/amkocluster_controller.go
@@ -18,10 +18,11 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -51,40 +52,42 @@ type AMKOClusterReconciler struct {
 func (r *AMKOClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
 
+	ctrlResultRequeue := ctrl.Result{
+		RequeueAfter: time.Second * 10,
+	}
+	ctrlResultNoRequeue := ctrl.Result{
+		Requeue: false,
+	}
+
 	// check how many amkocluster objects are present, only 1 allowed per cluster
 	var amkoClusterList amkov1alpha1.AMKOClusterList
 	err := r.List(ctx, &amkoClusterList)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("AMKOClusterObjects can't be listed, err: %v", err)
+		return ctrlResultNoRequeue, fmt.Errorf("AMKOClusterObjects can't be listed, err: %v", err)
 	}
 	if len(amkoClusterList.Items) > 1 {
-		return reconcile.Result{}, fmt.Errorf("only one AMKOClusterObject allowed per cluster")
+		return ctrlResultNoRequeue, fmt.Errorf("only one AMKOClusterObject allowed per cluster")
 	}
 
 	if len(amkoClusterList.Items) == 0 {
 		log.Log.Info("No AMKOCluster object available on this cluster, nothing to do")
-		return reconcile.Result{}, nil
-	}
-	// the Reconcile function can be called for 3 objects: AMKOCluster, GC and GDP objects
-	// we have to determine what kind of an object this function is getting called for.
-	// var amkoClusterName, amkoClusterNS string
-	// amkoClusterPresent := false
-	var amkoCluster amkov1alpha1.AMKOCluster
-	if len(amkoClusterList.Items) == 1 {
-		amkoCluster = amkoClusterList.Items[0]
-		// update the status of AMKOCluster
-		statusErr := r.UpdateAMKOClusterStatus(ctx, FederationTypeStatus, StatusMsgFederating, "", &amkoCluster)
-		if statusErr != nil {
-			return ctrl.Result{
-				RequeueAfter: time.Second * 5,
-			}, statusErr
-		}
+		return ctrlResultNoRequeue, nil
 	}
 
+	amkoCluster := amkoClusterList.Items[0]
+	updatedAMKOCluster := amkoCluster.DeepCopy()
+	// empty out the status
+	updatedAMKOCluster.Status.Conditions = []amkov1alpha1.AMKOClusterCondition{}
+
+	defer r.UpdateStatus(updatedAMKOCluster)
+
+	// the Reconcile function can be called for 3 objects: AMKOCluster, GC and GDP objects
+	// we have to determine what kind of an object this function is getting called for.
 	if IsObjAMKOClusterType(ctx, req.Name) {
-		if err != nil && errors.IsNotFound(err) {
+		if err != nil && k8serrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		} else if err != nil {
+			// don't requeue, it will get called when AMKOCluster is fixed
 			return ctrl.Result{}, err
 		}
 	}
@@ -92,149 +95,203 @@ func (r *AMKOClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// check if this AMKO is the leader
 	if !amkoCluster.Spec.IsLeader {
 		log.Log.Info("AMKO is not a leader, will return")
-		statusErr := r.UpdateAMKOClusterStatus(ctx, FederationTypeStatus, StatusMsgNotALeader, "AMKO not a leader", &amkoCluster)
-		if statusErr != nil {
-			return ctrl.Result{
-				RequeueAfter: time.Second * 5,
-			}, statusErr
+		if statusErr := r.UpdateAMKOClusterStatus(ctx, CurrentAMKOClusterValidationStatusType,
+			StatusMsgNotALeader, "AMKO not a leader", nil, updatedAMKOCluster); statusErr != nil {
+			return ctrlResultRequeue, statusErr
 		}
-		return ctrl.Result{}, nil
+		// don't requeue if not a leader
+		return ctrlResultNoRequeue, nil
 	}
 
 	// verify the basic sanity of the AMKOCluster object
-	err = r.VerifyAMKOClusterSanity(&amkoCluster)
-	if err != nil {
-		statusErr := r.UpdateAMKOClusterStatus(ctx, FederationTypeStatus, StatusMsgFederationFailure, err.Error(), &amkoCluster)
-		if statusErr != nil {
-			return ctrl.Result{
-				RequeueAfter: time.Second * 5,
-			}, statusErr
-		}
-		return reconcile.Result{}, err
+	if err := r.ValidateAMKOClusterSanityAndUpdateStatus(ctx, updatedAMKOCluster); err != nil {
+		// don't requeue, since Reconcile will get called anyway once the error is fixed
+		// in the AMKOCluster object
+		return ctrlResultNoRequeue, err
 	}
 
-	// fetch the member clusters' contexts
-	memberClusters, err := FetchMemberClusterContexts(ctx, amkoCluster.DeepCopy())
+	// fetch the member clusters' contexts and update status
+	memberClusters, err := r.FetchMemberClusterContextsAndUpdateStatus(ctx, updatedAMKOCluster)
 	if err != nil {
-		statusErr := r.UpdateAMKOClusterStatus(ctx, FederationTypeStatus, StatusMsgFederationFailure, err.Error(), &amkoCluster)
-		if statusErr != nil {
-			return ctrl.Result{
-				RequeueAfter: time.Second * 5,
-			}, statusErr
-		}
-		return reconcile.Result{}, fmt.Errorf("error in fetching member cluster contexts: %v", err)
+		return ctrlResultRequeue, err
 	}
 
-	// validate member clusters
-	err = ValidateMemberClusters(ctx, memberClusters, amkoCluster.Spec.Version)
+	// validate member clusters and update status
+	validClusters, err := r.ValidateMemberClustersAndUpdateStatus(ctx, memberClusters, updatedAMKOCluster)
 	if err != nil {
-		statusErr := r.UpdateAMKOClusterStatus(ctx, FederationTypeStatus, StatusMsgFederationFailure, err.Error(), &amkoCluster)
-		if statusErr != nil {
-			return ctrl.Result{
-				RequeueAfter: time.Second * 5,
-			}, statusErr
-		}
-		return reconcile.Result{}, fmt.Errorf("error in validating the member clusters: %v", err)
+		return ctrlResultRequeue, err
 	}
 
 	// Federate the GSLBConfig object on all member clusters
-	err = r.FederateGSLBConfig(ctx, memberClusters)
-	if err != nil {
-		statusErr := r.UpdateAMKOClusterStatus(ctx, FederationTypeStatus, StatusMsgFederationFailure, err.Error(), &amkoCluster)
-		if statusErr != nil {
-			return ctrl.Result{
-				RequeueAfter: time.Second * 5,
-			}, statusErr
-		}
-		return reconcile.Result{}, fmt.Errorf("error in federating GSLBConfig object: %v", err)
+	if err := r.FederateGSLBConfigAndUpdateStatus(ctx, validClusters, updatedAMKOCluster); err != nil {
+		return ctrlResultRequeue, err
 	}
 
-	err = r.FederateGDP(ctx, memberClusters)
-	if err != nil {
-		statusErr := r.UpdateAMKOClusterStatus(ctx, FederationTypeStatus, StatusMsgFederationFailure, err.Error(), &amkoCluster)
-		if statusErr != nil {
-			return ctrl.Result{
-				RequeueAfter: time.Second * 5,
-			}, statusErr
-		}
-		return reconcile.Result{}, fmt.Errorf("error in federating GDP object: %v", err)
-	}
-
-	// update the status of AMKOCluster
-	err = r.UpdateAMKOClusterStatus(ctx, FederationTypeStatus, StatusMsgFederationSuccess, "", &amkoCluster)
-	if err != nil {
-		return ctrl.Result{
-			RequeueAfter: time.Second * 5,
-		}, err
+	// Federate the GDP object on all member clusters
+	if err := r.FederateGDPAndUpdateStatus(ctx, validClusters, updatedAMKOCluster); err != nil {
+		return ctrlResultRequeue, err
 	}
 
 	return ctrl.Result{}, nil
 }
 
-func (r *AMKOClusterReconciler) FederateGSLBConfig(ctx context.Context, memberClusters []KubeContextDetails) error {
+func (r *AMKOClusterReconciler) FetchMemberClusterContextsAndUpdateStatus(ctx context.Context, amkoCluster *amkov1alpha1.AMKOCluster) ([]KubeContextDetails, error) {
+	memberClusters, errClusters, err := FetchMemberClusterContexts(ctx, amkoCluster.DeepCopy())
+
+	if err != nil {
+		// update the error message in the AMKOCluster status field
+		if statusErr := r.UpdateAMKOClusterStatus(ctx, ClusterContextsStatusType, "", err.Error(),
+			errClusters, amkoCluster); statusErr != nil {
+			return nil, statusErr
+		}
+		// errors on which the execution should be stopped here and retried:
+		// - bad kubeconfig
+		// - error in generating a temporary kubeconfig file
+		return nil, fmt.Errorf("error in fetching member cluster contexts: %v", err)
+	} else {
+		if statusErr := r.UpdateAMKOClusterStatus(ctx, ClusterContextsStatusType, "", "",
+			errClusters, amkoCluster); statusErr != nil {
+			return nil, statusErr
+		}
+	}
+
+	// if memberClusters list is empty, clear the rest of the status fields and return
+	if len(memberClusters) == 0 {
+		return nil, fmt.Errorf("no valid cluster contexts found")
+	}
+
+	return memberClusters, nil
+}
+
+func (r *AMKOClusterReconciler) ValidateAMKOClusterSanityAndUpdateStatus(ctx context.Context,
+	amkoCluster *amkov1alpha1.AMKOCluster) error {
+
+	err := r.VerifyAMKOClusterSanity(amkoCluster)
+	if err != nil {
+		if statusErr := r.UpdateAMKOClusterStatus(ctx, CurrentAMKOClusterValidationStatusType,
+			StatusMsgInvalidAMKOCluster, err.Error(), nil, amkoCluster); statusErr != nil {
+			return statusErr
+		}
+		return err
+	}
+	return r.UpdateAMKOClusterStatus(ctx, CurrentAMKOClusterValidationStatusType,
+		"", "", nil, amkoCluster)
+}
+
+func (r *AMKOClusterReconciler) ValidateMemberClustersAndUpdateStatus(ctx context.Context, memberClusters []KubeContextDetails,
+	amkoCluster *amkov1alpha1.AMKOCluster) ([]KubeContextDetails, error) {
+
+	validClusters, errClusters, err := ValidateMemberClusters(ctx, memberClusters, amkoCluster.Spec.Version)
+
+	if err != nil {
+		if statusErr := r.UpdateAMKOClusterStatus(ctx, MemberValidationStatusType, "",
+			err.Error(), errClusters, amkoCluster); statusErr != nil {
+			return nil, statusErr
+		}
+		// errors on which the execution should be stopped here and retried:
+		// - another cluster has a leader AMKO instance
+		return nil, fmt.Errorf("error in validating the member clusters: %v", err)
+	} else {
+		if statusErr := r.UpdateAMKOClusterStatus(ctx, MemberValidationStatusType, "",
+			"", errClusters, amkoCluster); statusErr != nil {
+			return nil, statusErr
+		}
+	}
+
+	// if no valid clusters left, no point continuing
+	if len(validClusters) == 0 {
+		log.Log.Info("no valid clusters to federate on")
+		return nil, fmt.Errorf("no valid clusters left to federate on")
+	}
+
+	return validClusters, nil
+}
+
+func (r *AMKOClusterReconciler) FederateGSLBConfigAndUpdateStatus(ctx context.Context, validClusters []KubeContextDetails,
+	amkoCluster *amkov1alpha1.AMKOCluster) error {
+	errClusters, err := r.FederateGSLBConfig(ctx, validClusters)
+	if statusErr := r.UpdateAMKOClusterStatus(ctx, GSLBConfigFederationStatusType, "",
+		getErrorMsg(err), errClusters, amkoCluster); statusErr != nil {
+		return statusErr
+	}
+	if err != nil {
+		// errors on which the execution will stop here and will be retried (indicating that
+		// the current cluster is in a bad shape):
+		// - CRD for GSLBConfig is absent in the current cluster
+		// - more than one GSLBConfig objects in the current cluster
+		return fmt.Errorf("error in federating GSLBConfig object: %v", err)
+	}
+	return nil
+}
+
+func (r *AMKOClusterReconciler) FederateGDPAndUpdateStatus(ctx context.Context, validClusters []KubeContextDetails,
+	amkoCluster *amkov1alpha1.AMKOCluster) error {
+	// Federate the GDP object on all member clusters
+	errClusters, err := r.FederateGDP(ctx, validClusters)
+	if statusErr := r.UpdateAMKOClusterStatus(ctx, GDPFederationStatusType, "",
+		getErrorMsg(err), errClusters, amkoCluster); statusErr != nil {
+		return statusErr
+	}
+	if err != nil {
+		// errors on which the execution will stop here and will be retried:
+		// - CRD for GDP is absent in the current cluster
+		// - more than one GDPs in the current cluster
+		return fmt.Errorf("error in federating GDP object: %v", err)
+	}
+	return nil
+}
+
+func (r *AMKOClusterReconciler) FederateGSLBConfig(ctx context.Context, memberClusters []KubeContextDetails) ([]ClusterErrorMsg, error) {
 	// Determine the state that we need to federate across all member clusters
 	var currGCList gslbalphav1.GSLBConfigList
 	err := r.List(ctx, &currGCList, &client.ListOptions{
 		Namespace: AviSystemNS,
 	})
 	if err != nil {
-		return fmt.Errorf("cannot list GSLBConfig list on current cluster in %s namespace: %v",
+		// current cluster's state is not right, need to stop here
+		return nil, fmt.Errorf("cannot list GSLBConfig list on current cluster in %s namespace: %v",
 			AviSystemNS, err)
 	}
 
 	if len(currGCList.Items) > 1 {
-		return fmt.Errorf("more than one GSLBConfig objects are present in the current cluster")
+		// current cluster is in a state of error, have to stop here
+		return nil, fmt.Errorf("more than one GSLBConfig objects are present in the current cluster")
 	}
 
 	// if no GC objects exist, we need to sync all member clusters to the same state
 	// which would mean, we need to delete GCs on all member clusters (if any)
 	if len(currGCList.Items) == 0 {
-		if err = DeleteObjsOnAllMemberClusters(ctx, memberClusters, AviSystemNS, &gslbalphav1.GSLBConfig{}); err != nil {
-			return fmt.Errorf("error in removing GSLBConfig objects on member clusters: %v", err)
-		}
-		return nil
+		return DeleteObjsOnAllMemberClusters(ctx, memberClusters, AviSystemNS, &gslbalphav1.GSLBConfig{}), nil
 	}
 
 	// if a GC object exists in the current cluster, we need to make sure that all the member
 	// clusters have only this GC object in the avi-system namespace.
-	if err = FederateGCObjectOnMemberClusters(ctx, memberClusters, currGCList.Items[0].DeepCopy()); err != nil {
-		return fmt.Errorf("error in federating GSLBConfig object to member clusters: %v", err)
-	}
-
-	return nil
+	return FederateGCObjectOnMemberClusters(ctx, memberClusters, currGCList.Items[0].DeepCopy()), nil
 }
 
-func (r *AMKOClusterReconciler) FederateGDP(ctx context.Context, memberClusters []KubeContextDetails) error {
+func (r *AMKOClusterReconciler) FederateGDP(ctx context.Context, memberClusters []KubeContextDetails) ([]ClusterErrorMsg, error) {
 	// Determine the state that we need to federate across all member clusters
 	var currGDPList gdpalphav2.GlobalDeploymentPolicyList
 	err := r.List(ctx, &currGDPList, &client.ListOptions{
 		Namespace: AviSystemNS,
 	})
 	if err != nil {
-		return fmt.Errorf("cannot list GlobalDeploymentPolicy list on current cluster in %s namespace: %v",
+		return nil, fmt.Errorf("cannot list GlobalDeploymentPolicy list on current cluster in %s namespace: %v",
 			AviSystemNS, err)
 	}
 
 	if len(currGDPList.Items) > 1 {
-		return fmt.Errorf("more than one GlobalDeploymentPolicies are present in the current cluster")
+		return nil, fmt.Errorf("more than one GlobalDeploymentPolicies are present in the current cluster")
 	}
 
 	// if no GDP objects exist, we need to sync all member clusters to the same state
 	// which would mean, we need to delete GDPs on all member clusters (if any)
 	if len(currGDPList.Items) == 0 {
-		if err = DeleteObjsOnAllMemberClusters(ctx, memberClusters, AviSystemNS, &gdpalphav2.GlobalDeploymentPolicy{}); err != nil {
-			return fmt.Errorf("error in removing GlobalDeploymentPolicies on member clusters: %v", err)
-		}
-		return nil
+		return DeleteObjsOnAllMemberClusters(ctx, memberClusters, AviSystemNS, &gdpalphav2.GlobalDeploymentPolicy{}), nil
 	}
-
 	// if a GDP object exists in the current cluster, we need to make sure that all the member
 	// clusters have only this GDP object in the avi-system namespace.
-	if err = FederateGDPObjectOnMemberClusters(ctx, memberClusters, currGDPList.Items[0].DeepCopy()); err != nil {
-		return fmt.Errorf("error in federating GSLBConfig object to member clusters: %v", err)
-	}
-
-	return nil
+	return FederateGDPObjectOnMemberClusters(ctx, memberClusters, currGDPList.Items[0].DeepCopy()), nil
 }
 
 func (r *AMKOClusterReconciler) GetObjectsToBeFederated(ctx context.Context) ([]client.Object, error) {
@@ -276,17 +333,17 @@ func (r *AMKOClusterReconciler) GetObjectsToBeFederated(ctx context.Context) ([]
 	return objList, nil
 }
 
-func (r *AMKOClusterReconciler) FetchMemberClusterContexts(ctx context.Context, amkoCluster *amkov1alpha1.AMKOCluster) ([]KubeContextDetails, error) {
+func (r *AMKOClusterReconciler) FetchMemberClusterContexts(ctx context.Context, amkoCluster *amkov1alpha1.AMKOCluster) ([]KubeContextDetails, []ClusterErrorMsg, error) {
 	err := generateTempKubeConfig()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	memberClusters, err := InitMemberClusterContexts(ctx, amkoCluster.Spec.ClusterContext, amkoCluster.Spec.Clusters)
+	memberClusters, errClusters, err := InitMemberClusterContexts(ctx, amkoCluster.Spec.ClusterContext, amkoCluster.Spec.Clusters)
 	if err != nil {
-		return nil, fmt.Errorf("error in initializing member cluster contexts: %v", err)
+		return nil, nil, fmt.Errorf("error in initialising member cluster contexts: %v", err)
 	}
 
-	return memberClusters, nil
+	return memberClusters, errClusters, nil
 }
 
 func (r *AMKOClusterReconciler) VerifyAMKOClusterSanity(amkoCluster *amkov1alpha1.AMKOCluster) error {
@@ -307,36 +364,68 @@ func (r *AMKOClusterReconciler) VerifyAMKOClusterSanity(amkoCluster *amkov1alpha
 	return nil
 }
 
-func (r *AMKOClusterReconciler) UpdateAMKOClusterStatus(ctx context.Context, statusType, statusMsg, reason string, amkoCluster *amkov1alpha1.AMKOCluster) error {
-	updatedAMKOCluster := amkoCluster.DeepCopy()
-	log.Log.Info("updating status", "status type", statusType, "status msg", statusMsg, "reason", reason)
+func (r *AMKOClusterReconciler) UpdateStatus(updatedAMKOCluster *amkov1alpha1.AMKOCluster) {
+	currAMKOClusterList := amkov1alpha1.AMKOClusterList{}
+	if err := r.List(context.TODO(), &currAMKOClusterList, &client.ListOptions{
+		Namespace: AviSystemNS,
+	}); err != nil {
+		log.Log.Error(err, "unable to get AMKOCluster list on avi-system namespace")
+		return
+	}
+
+	if len(currAMKOClusterList.Items) != 1 {
+		log.Log.Error(errors.New("no AMKOCluster to be updated"), "unable to get AMKOCluster list on avi-system namespace")
+		return
+	}
+
+	// currAMKOClusterList.Items[0].Status.Conditions = []amkov1alpha1.AMKOClusterCondition{}
+	log.Log.Info("updated AMKO Cluster status", "status", updatedAMKOCluster.Status.Conditions)
+	if err := r.PatchAMKOClusterStatus(context.TODO(), &currAMKOClusterList.Items[0],
+		updatedAMKOCluster); err != nil {
+		log.Log.Error(err, "error while patching AMKOCluster status")
+	}
+}
+
+func (r *AMKOClusterReconciler) UpdateAMKOClusterStatus(ctx context.Context, statusType int,
+	statusMsg, reason string, errClusters []ClusterErrorMsg,
+	updatedAMKOCluster *amkov1alpha1.AMKOCluster) error {
+
+	condition, err := getStatusCondition(statusType, statusMsg, reason, errClusters)
+	if err != nil {
+		log.Log.Error(err, "error while generating status condition")
+		return err
+	}
+	log.Log.Info("status condition", "condition", condition)
+
 	// get the previous status
-	conditions := amkoCluster.Status.Conditions
+	conditions := updatedAMKOCluster.Status.Conditions
 	if len(conditions) == 0 {
-		// initialize a new set
+		// initialise a new set
 		updatedAMKOCluster.Status.Conditions = []amkov1alpha1.AMKOClusterCondition{
-			getStatusCondition(statusType, statusMsg, reason),
+			condition,
 		}
-		return r.PatchAMKOClusterStatus(ctx, amkoCluster, updatedAMKOCluster)
+		return nil
 	}
 
 	// conditions already present, update the one that we need for statusType
 	for idx, c := range conditions {
-		if c.Type == statusType {
-			updatedAMKOCluster.Status.Conditions[idx].Status = statusMsg
-			updatedAMKOCluster.Status.Conditions[idx].Reason = reason
-			return r.PatchAMKOClusterStatus(ctx, amkoCluster, updatedAMKOCluster)
+		if c.Type == condition.Type {
+			updatedAMKOCluster.Status.Conditions[idx].Type = condition.Type
+			updatedAMKOCluster.Status.Conditions[idx].Status = condition.Status
+			updatedAMKOCluster.Status.Conditions[idx].Reason = condition.Reason
+			return nil
 		}
 	}
 
 	// no such condition with status type, add a new one
-	amkoCluster.Status.Conditions = append(updatedAMKOCluster.Status.Conditions,
-		getStatusCondition(statusType, statusMsg, reason))
-	return r.PatchAMKOClusterStatus(ctx, amkoCluster, updatedAMKOCluster)
+	updatedAMKOCluster.Status.Conditions = append(updatedAMKOCluster.Status.Conditions, condition)
+
+	tmpObj := amkov1alpha1.AMKOCluster{}
+	r.Get(ctx, types.NamespacedName{Name: tmpObj.Name, Namespace: tmpObj.Namespace}, &tmpObj)
+	return nil
 }
 
 func (r *AMKOClusterReconciler) PatchAMKOClusterStatus(ctx context.Context, amkoCluster, updatedAMKOCluster *amkov1alpha1.AMKOCluster) error {
-	amkoCluster.Status = amkov1alpha1.AMKOClusterStatus{}
 	patch := client.MergeFrom(amkoCluster.DeepCopy())
 	err := r.Status().Patch(ctx, updatedAMKOCluster, patch)
 	if err != nil {

--- a/federator/controllers/status.go
+++ b/federator/controllers/status.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+	"strings"
+
+	amkov1alpha1 "github.com/vmware/global-load-balancing-services-for-kubernetes/federator/api/v1alpha1"
+)
+
+const (
+	// Status field types
+	CurrentAMKOClusterValidationStatusType = 0
+	ClusterContextsStatusType              = 1
+	MemberValidationStatusType             = 2
+	GSLBConfigFederationStatusType         = 3
+	GDPFederationStatusType                = 4
+
+	// Status field type values
+	CurrentAMKOClusterValidationStatusField = "current AMKOCluster Validation"
+	ClusterContextsStatusField              = "member cluster initialisation"
+	MemberValidationStatusField             = "member cluster validation"
+	GSLBConfigFederationStatusField         = "GSLBConfig Federation"
+	GDPFederationStatusField                = "GDP Federation"
+
+	StatusMsgInvalidAMKOCluster = "invalid AMKOCluster object"
+	StatusMsgValidAMKOCluster   = "valid AMKOCluster object"
+
+	StatusMsgClusterClientsInvalid     = "member cluster clients invalid"
+	StatusMsgSomeClusterClientsInvalid = "some member cluster clients couldn't be fetched"
+	StatusMsgClusterClientsSuccess     = "all cluster clients fetched"
+
+	StatusMemberValidationFailure  = "validation of member clusters failed"
+	StatusMembersInvalid           = "error in validating some member clusters"
+	StatusMembersValidationSuccess = "validated all member clusters"
+
+	StatusGSLBConfigFederationFailure     = "failure in federation"
+	StatusSomeGSLBConfigFederationFailure = "error in federating to some clusters"
+	StatusGSLBConfigFederationSuccess     = "federated to all valid clusters successfully"
+
+	StatusGDPFederationFailure     = "failure in federation"
+	StatusSomeGDPFederationFailure = "error in federating to some clusters"
+	StatusGDPFederationSuccess     = "federated to all valid clusters successfully"
+
+	StatusMsgFederationFailure = "failure in federating objects"
+	StatusMsgFederationSuccess = "federation successful"
+	StatusMsgNotALeader        = "current AMKO is a follower, won't federate"
+
+	ErrMembersValidation = "failure in validating some members"
+	ErrFederationFailure = "object couldn't be federated to all clusters"
+	ErrInitClientContext = "error in initializing member custer context"
+)
+
+type StatusMsgRecord struct {
+	statusType string
+	allFailed  string
+	someFailed string
+	success    string
+}
+
+var statusMsgTypes map[int]*StatusMsgRecord = map[int]*StatusMsgRecord{
+	CurrentAMKOClusterValidationStatusType: {
+		statusType: CurrentAMKOClusterValidationStatusField,
+		allFailed:  StatusMsgInvalidAMKOCluster,
+		success:    StatusMsgValidAMKOCluster,
+	},
+
+	ClusterContextsStatusType: {
+		statusType: ClusterContextsStatusField,
+		allFailed:  StatusMsgClusterClientsInvalid,
+		someFailed: StatusMsgSomeClusterClientsInvalid,
+		success:    StatusMsgClusterClientsSuccess,
+	},
+
+	MemberValidationStatusType: {
+		statusType: MemberValidationStatusField,
+		allFailed:  StatusMsgClusterClientsInvalid,
+		someFailed: StatusMembersInvalid,
+		success:    StatusMembersValidationSuccess,
+	},
+
+	GSLBConfigFederationStatusType: {
+		statusType: GSLBConfigFederationStatusField,
+		allFailed:  StatusGSLBConfigFederationFailure,
+		someFailed: StatusSomeGSLBConfigFederationFailure,
+		success:    StatusGSLBConfigFederationSuccess,
+	},
+
+	GDPFederationStatusType: {
+		statusType: GDPFederationStatusField,
+		allFailed:  StatusGDPFederationFailure,
+		someFailed: StatusSomeGDPFederationFailure,
+		success:    StatusGDPFederationSuccess,
+	},
+}
+
+func getClusterErrMsg(errClusters []ClusterErrorMsg) string {
+	var errList []string
+
+	for _, m := range errClusters {
+		errList = append(errList, m.err.Error())
+	}
+
+	return strings.Join(errList, ",")
+}
+
+func getStatusCondition(statusType int, statusMsg, reason string,
+	errClusters []ClusterErrorMsg) (amkov1alpha1.AMKOClusterCondition, error) {
+
+	statusMsgType, ok := statusMsgTypes[statusType]
+	if !ok {
+		return amkov1alpha1.AMKOClusterCondition{}, fmt.Errorf("error in identifying error type %d", statusType)
+	}
+	amkoClusterCondition := amkov1alpha1.AMKOClusterCondition{
+		Type:   statusMsgType.statusType,
+		Status: statusMsg,
+	}
+
+	if len(errClusters) == 0 {
+		// if there are no error clusters and the reason field is empty, then it
+		// has to be a success message.
+		// the reason will be non-empty only if there's a hard error, where the federator
+		// has to stop and retry.
+		if reason == "" {
+			// success field
+			amkoClusterCondition.Status = statusMsgType.success
+			return amkoClusterCondition, nil
+		}
+		amkoClusterCondition.Reason = reason
+		amkoClusterCondition.Status = statusMsgType.allFailed
+		return amkoClusterCondition, nil
+	}
+	amkoClusterCondition.Reason = getClusterErrMsg(errClusters)
+	amkoClusterCondition.Status = statusMsgType.someFailed
+
+	return amkoClusterCondition, nil
+}
+
+func getErrorMsg(err error) string {
+	if err != nil {
+		return err.Error()
+	}
+	return ""
+}

--- a/federator/controllers/suite_test.go
+++ b/federator/controllers/suite_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Federator Validation", func() {
 		})
 	})
 
-	//   when and AMKOCluster object is added with an invalid cluster list
+	//   when an AMKOCluster object is added with an invalid cluster list
 	//     status of AMKOCluster object should contain error
 	//     no federation should happen
 	Context("when an AMKOCluster object has invalid cluster list", func() {
@@ -234,6 +234,8 @@ var _ = Describe("Federation Operation", func() {
 		Specify("AMKOCluster's federation status should indicate success", func() {
 			By("Creating a valid AMKOCluster object on both the clusters")
 			ctx := context.Background()
+			gcObj.ObjectMeta.ResourceVersion = ""
+			gdpObj.ObjectMeta.ResourceVersion = ""
 			createTestGCAndGDPObjs(ctx, k8sClient1, &gcObj, &gdpObj)
 			Expect(k8sClient1.Create(ctx, &amkoCluster1)).Should(Succeed())
 			Expect(k8sClient2.Create(ctx, &amkoCluster2)).Should(Succeed())
@@ -405,6 +407,152 @@ var _ = Describe("Federation Operation", func() {
 			deleteTestGCAndGDPObj(ctx, k8sClient1, &gcObj, &gdpObj)
 			Expect(k8sClient2.Delete(ctx, &amkoCluster2)).Should(Succeed())
 			deleteTestGCAndGDPObj(ctx, k8sClient2, &gcObj, &gdpObj)
+		})
+	})
+})
+
+var _ = Describe("Federation Consolidation Operations", func() {
+	amkoCluster1 := getTestAMKOClusterObj(Cluster1, true)
+	amkoCluster2 := getTestAMKOClusterObj(Cluster2, false)
+	gcObj := getTestGCObj()
+	gdpObj := getTestGDPObject()
+
+	alternateGCObj := getTestGCObj()
+	alternateGCObj.Name = "alt-test-gc"
+	alternateGDPObj := getTestGDPObject()
+	alternateGDPObj.Name = "alt-test-gdp"
+
+	//   when a valid AMKOCluster object is present on both clusters, but multiple GSLBConfig and GDP objects on the follower cluster
+	//     status should reflect federation success
+	//     federator should delete the non-relevant GSLBConfigs on follower cluster
+	//     GDP object should be federated
+	Context("when a valid AMKOCluster object is added to both clusters and cluster2 has 2 GSLBConfigs and 2 GDPs", func() {
+		Specify("AMKOCluster's federation status should indicate success", func() {
+			By("Creating a valid AMKOCluster object on both the clusters and an extra GSLBConfig on cluster2")
+			ctx := context.Background()
+			createTestGCAndGDPObjs(ctx, k8sClient1, &gcObj, &gdpObj)
+			Expect(k8sClient2.Create(ctx, &alternateGCObj)).Should(Succeed())
+			Expect(k8sClient2.Create(ctx, &alternateGDPObj)).Should(Succeed())
+
+			Expect(k8sClient1.Create(ctx, &amkoCluster1)).Should(Succeed())
+			Expect(k8sClient2.Create(ctx, &amkoCluster2)).Should(Succeed())
+			VerifyTestAMKOClusterObjectSuccess(k8sClient1)
+		})
+
+		It("should give an error when the extra gslbconfig object is fetched from cluster 2", func() {
+			ctx := context.Background()
+			obj := gslbalphav1.GSLBConfig{}
+			Expect(k8sClient2.Get(ctx, types.NamespacedName{
+				Namespace: alternateGCObj.Namespace,
+				Name:      alternateGCObj.Name,
+			}, &obj)).ShouldNot(Succeed())
+		})
+
+		It("should give an error when the extra gdp object is fetched from cluster 2", func() {
+			ctx := context.Background()
+			obj := gdpalphav2.GlobalDeploymentPolicy{}
+			Expect(k8sClient2.Get(ctx, types.NamespacedName{
+				Namespace: alternateGDPObj.Namespace,
+				Name:      alternateGDPObj.Name,
+			}, &obj)).ShouldNot(Succeed())
+		})
+
+		Specify("one each of GC and GDP objects should be federated to present on cluster 2", func() {
+			// this does number of object checks anyway
+			TestGCGDPExist(k8sClient2)
+		})
+
+		It("should federate primary GC updates to cluster2", func() {
+			// make sure that the updates to the primary GC object is still federated
+			By("updating the GC object on cluster1")
+			ctx := context.Background()
+			gcObj.Spec.RefreshInterval = 999
+			Expect(k8sClient1.Update(ctx, &gcObj)).Should(Succeed())
+			Eventually(func() int {
+				var obj gslbalphav1.GSLBConfig
+				Expect(k8sClient2.Get(context.TODO(),
+					types.NamespacedName{
+						Name:      gcObj.Name,
+						Namespace: gcObj.Namespace},
+					&obj)).Should(Succeed())
+				return obj.Spec.RefreshInterval
+			}, 5*time.Second, 1*time.Second).Should(Equal(999))
+		})
+
+		It("should federate primary GDP updates to cluster2", func() {
+			// make sure that the updates to the primary GDP object is still federated
+			By("updating the GDP object on cluster1")
+			ctx := context.Background()
+			ttl := 1000
+			gdpObj.Spec.TTL = &ttl
+			Expect(k8sClient1.Update(ctx, &gdpObj)).Should(Succeed())
+			Eventually(func() int {
+				var obj gdpalphav2.GlobalDeploymentPolicy
+				Expect(k8sClient2.Get(context.TODO(),
+					types.NamespacedName{
+						Name:      gdpObj.Name,
+						Namespace: gdpObj.Namespace},
+					&obj)).Should(Succeed())
+				return *obj.Spec.TTL
+			}, 5*time.Second, 1*time.Second).Should(Equal(1000))
+		})
+
+		Specify("deletion of AMKOCluster, GC and GDP is successful", func() {
+			CleanupTestObjects(k8sClient1, k8sClient2, &amkoCluster1, &amkoCluster2,
+				&gcObj, &gdpObj)
+		})
+	})
+
+	//   when a valid AMKOCluster object is present on both clusters and GC/GDP is deleted
+	//     status should reflect federation success
+	//     federator should delete the only GC/GDP object on cluster2
+	Context("when a valid AMKOCluster object is added to both clusters and GC/GDP is deleted", func() {
+		Specify("AMKOCluster's federation status should indicate success", func() {
+			By("Creating a valid AMKOCluster object on both the clusters")
+			ctx := context.Background()
+			gcObj.SetResourceVersion("")
+			gdpObj.SetResourceVersion("")
+			amkoCluster1.SetResourceVersion("")
+			amkoCluster2.SetResourceVersion("")
+			createTestGCAndGDPObjs(ctx, k8sClient1, &gcObj, &gdpObj)
+			Expect(k8sClient1.Create(ctx, &amkoCluster1)).Should(Succeed())
+			Expect(k8sClient2.Create(ctx, &amkoCluster2)).Should(Succeed())
+			VerifyTestAMKOClusterObjectSuccess(k8sClient1)
+		})
+
+		It("should federate GC and GDP objects on member clusters", func() {
+			TestGCGDPExist(k8sClient2)
+		})
+
+		It("Should delete the GC on cluster2 when GC on cluster1 is deleted", func() {
+			ctx := context.Background()
+			Expect(k8sClient1.Delete(ctx, &gcObj)).Should(Succeed())
+
+			Eventually(func() int {
+				gcList := gslbalphav1.GSLBConfigList{}
+				Expect(k8sClient2.List(ctx, &gcList, &client.ListOptions{
+					Namespace: gcObj.Namespace,
+				})).Should(Succeed())
+				return len(gcList.Items)
+			}, 5*time.Second, 1*time.Second).Should(BeZero())
+		})
+
+		It("Should delete the GDP on cluster2 when GDP on cluster1 is deleted", func() {
+			ctx := context.Background()
+			Expect(k8sClient1.Delete(ctx, &gdpObj)).Should(Succeed())
+
+			Eventually(func() int {
+				gdpList := gdpalphav2.GlobalDeploymentPolicyList{}
+				Expect(k8sClient2.List(ctx, &gdpList, &client.ListOptions{
+					Namespace: gdpObj.Namespace,
+				})).Should(Succeed())
+				return len(gdpList.Items)
+			}, 5*time.Second, 1*time.Second).Should(BeZero())
+		})
+
+		Specify("deletion of AMKOCluster, GC and GDP is successful", func() {
+			CleanupTestObjects(k8sClient1, k8sClient2, &amkoCluster1, &amkoCluster2,
+				&gcObj, &gdpObj)
 		})
 	})
 })


### PR DESCRIPTION
The AMKO federator should completely sync the GSLBConfigs and GDPs
across all member clusters. This would mean:
1. If there are multiple GC/GDP objects on the member clusters, the
   federator should remove the additional GDP/GCs.
2. If any of GC/GDP objects get deleted on the leader cluster, the
   federator should propagate the deletion events for the corresponding
   object to the member clusters as well. This means, if there are
   no GC/GDP objects on the leader cluster, there will be no GC/GDP
   objects on the member clusters.
3. If there are multiple GC/GDP objects on the leader cluster, this
   condition is already checked and is an error state.

TODO:
- [x] Add integration tests covering multiple GC/GDP objects.
- [x] Add integration tests covering delete events.

Additionally, this PR also takes care of taking a decision regarding
continuing with the federation depending on certain error conditions.

Currently, the federator returns even when there's a single error
while:
1. fetching/initialising the cluster contexts
2. Validating the member clusters
3. Federating the GSLBConfig objects
4. Federating the GDP objects

With this commit, we differentiate between different error conditions
and decide whether to stop the federation or continue on other clusters
based on error conditions.

Following are the error conditions and the actions of federator
and AMKO based on these conditions:

  While reading the current AMKOCluster object:
  1. Invalid AMKOCluster object:
     Federator: stop and retry
     AMKO: stop and reboot
  
  While building the kubeclients from the kubeconfig file:
  1. Generation of temp kube config:
     Federator: stop and retry
     AMKO: stop and reboot
  
  2. `kubeconfig` format is wrong, member cluster client build error
     Federator: stop and retry
     AMKO: stop and reboot
  
  3. Member cluster client init issue because of a n/w issue
     Federator: log an error and continue with other members
     AMKO: log an error and continue
  
  4. member cluster client init issue because of wrong server string, this
     can return timeout
     Federator: log an error and continue with other members
     AMKO: log an error and continue with other members
  
  5. member cluster client init issue because of wrong auth
     Federator: log an error and continue with other members
     AMKO: log an error and continue with other members
  
  While validating AMKOCluster objects in follower clusters:
  1. N/w error, packet drop
     Federator: stop the execution and retry (to avoid two leaders issue)
     AMKO: stop, log an error and reboot
  
  2. AMKOCluster CRD absent in any member cluster
     Federator: will skip this cluster and continue, error will be logged
     AMKO: will skip this cluster, error will be logged and continue

  3. More than one AMKOCluster objects in any member cluster
     Federator: check all the objects, if any of them is a leader, then
                federator will log an error and retry
     AMKO: check all the objects, if any of them is a leader, then AMKO
           won't proceed
  
  4. No AMKOCluster object present in any member cluster
     Federator: will skip this cluster and continue, error will be logged
     AMKO: will log an error for this cluster and continue
  
  5. Any member cluster is also a leader:
     Federator: Stop and retry
     AMKO: Stop and reboot
  
  6. Version mismatch with any member cluster
     Federator: will skip this cluster and continue, error will be logged
     AMKO: will skip this cluster and log an error

  Federation of GC and GDP:
  1. N/w error, packet drop: skip the cluster, record an error and
     conrtinue
  2. CRD absent: skip the cluster, record an error and continue

Each stage (cluster contexts fetching, clients initialsation and
member cluster validation) returns a set of valid clusters to continue
with. If at any point, there are no more valid clusters left, we stop
the federator execution and retry.
