### PR TITLE
Fix error messages and logging

### DIFF
--- a/federator/controllers/utils.go
+++ b/federator/controllers/utils.go
@@ -123,7 +123,7 @@ func UpdateObjOnMemberCluster(ctx context.Context, c client.Client, source,
 	}
 
 	if err := c.Update(ctx, target, &client.UpdateOptions{
-		FieldManager: "AMKO",
+		FieldManager: "AMKO-Federator",
 	}); err != nil {
 		return fmt.Errorf("can't update object %s/%s on cluster %s: %v", source.GetNamespace(),
 			source.GetName(), cname, err)

--- a/federator/main.go
+++ b/federator/main.go
@@ -61,9 +61,11 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+
 	opts := zap.Options{
 		Development: true,
 	}
+
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 

--- a/gslb/ingestion/bootup_handler.go
+++ b/gslb/ingestion/bootup_handler.go
@@ -187,6 +187,7 @@ func HandleBootup(cfg *restclient.Config) (bool, error) {
 		gslbutils.Logf("AMKOCluster object found and AMKO would start as leader")
 	} else {
 		gslbutils.Logf("AMKOCluster object found and AMKO would start as follower")
+		return false, nil
 	}
 
 	memberClusters, errClusters, err := federator.FetchMemberClusterContexts(context.TODO(), amkoCluster.DeepCopy())
@@ -194,7 +195,7 @@ func HandleBootup(cfg *restclient.Config) (bool, error) {
 		return false, fmt.Errorf("unrecoverable error, error in fetching member cluster contexts: %v", err)
 	}
 	if len(errClusters) != 0 {
-		gslbutils.Warnf("some member cluster contexts couldn't be fetched: %v, will ignore these", errClusters)
+		gslbutils.Warnf("some member cluster contexts couldn't be fetched: %s, will ignore these", federator.GetClusterErrMsg(errClusters))
 	}
 	gslbutils.Logf("memberClusters list found from amkoCluster object: %v", memberClusters)
 
@@ -203,7 +204,7 @@ func HandleBootup(cfg *restclient.Config) (bool, error) {
 		return false, fmt.Errorf("error in validating the member clusters: %v", err)
 	}
 	if len(errClusters) != 0 {
-		gslbutils.Warnf("some member clusters are invalid: %v, will ignore these", errClusters)
+		gslbutils.Warnf("some member clusters are invalid: %v, will ignore these", federator.GetClusterErrMsg(errClusters))
 	}
 	return currentLeader, nil
 }

--- a/gslb/nodes/avi_model_nodes.go
+++ b/gslb/nodes/avi_model_nodes.go
@@ -558,7 +558,7 @@ func (v *AviGSObjectGraph) AddUpdateGSMember(newMember AviGSK8sObj) bool {
 	}
 	// new member object
 	if !newMember.SyncVIPOnly && (newMember.ControllerUUID == "" || newMember.VirtualServiceUUID == "") {
-		gslbutils.Errf("gsName: %s, cluster: %s, namespace: %s, msg: controller UUID or VS UUID missing from the object, won't update member",
+		gslbutils.Errf("gsName: %s, cluster: %s, namespace: %s, member: %s, msg: controller UUID or VS UUID missing from the object, won't update member",
 			v.Name, newMember.Cluster, newMember.Namespace, newMember.Name)
 		return false
 	}


### PR DESCRIPTION
- If the current cluster's `AMKOCluster` object indicates that the
  current AMKO is not a leader, AMKO prints this error and goes into
  panic. The federator too indicates that the `AMKOCluster` object is
  invalid, which is not true. For AMKO, the fix is to just return
  on a follower cluster and wait forever. For the federator, the status
  message has been changed to: `won't federate objects`.

- Log messages have been fixed to print the member clusters' errors (if
  any) during bootup in AMKO.

- The manager name has been changed from `AMKO` to `AMKO-federator` in
  the federated objects, to avoid any confusion with the helm chart name
  in the manager field as `amko`.

- Other log fixes.