### PR TITLE
Enable logging to PVC if required for federator

### DIFF
--- a/federator/controllers/log.go
+++ b/federator/controllers/log.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+const (
+	DEFAULT_FILE_SUFFIX = "avi.log"
+)
+
+func getFilePath() string {
+	return strings.TrimLeft(os.Getenv("LOG_FILE_PATH")+"/", "/")
+}
+
+func getPodName() string {
+	return strings.TrimLeft(os.Getenv("POD_NAME")+".", ".")
+}
+
+// log file sample name /log/amko-0.amko-federator.log.1234
+func getFileName() string {
+	input := os.Getenv("LOG_FILE_NAME")
+	if input == "" {
+		input = DEFAULT_FILE_SUFFIX
+	}
+	fileName := fmt.Sprintf("%s%s%s.%d", getFilePath(), getPodName(), input, time.Now().Unix())
+	return fileName
+}
+
+// GetLogWriter returns a log writer if USE_PVC is set to true.
+// If USE_PVC is not defined, it returns a false indicating that
+// the default console should be used for logging.
+func GetLogWriter() (*lumberjack.Logger, bool, error) {
+	usePVC := os.Getenv("USE_PVC")
+
+	if usePVC != "true" {
+		return nil, false, nil
+	}
+
+	logPath := getFileName()
+	file, err := os.OpenFile(logPath,
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, false, fmt.Errorf("error in creating log file %s: %v", logPath, err)
+	}
+	if err := file.Close(); err != nil {
+		return nil, false, fmt.Errorf("error in closing log file, %s: %v", logPath, err)
+	}
+
+	newLogger := &lumberjack.Logger{
+		Filename:   logPath,
+		MaxSize:    500, // megabytes after which new file is created
+		MaxBackups: 5,   // number of backups
+		MaxAge:     28,  // days
+		Compress:   true,
+	}
+	return newLogger, true, nil
+}

--- a/federator/main.go
+++ b/federator/main.go
@@ -66,6 +66,15 @@ func main() {
 		Development: true,
 	}
 
+	newLogger, isExternalLog, err := controllers.GetLogWriter()
+	if err != nil {
+		setupLog.Error(err, "error while getting log writer")
+		return
+	}
+	if isExternalLog {
+		opts.DestWriter = newLogger
+	}
+
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 

--- a/gslb/ingestion/gslb.go
+++ b/gslb/ingestion/gslb.go
@@ -541,14 +541,15 @@ func AddGSLBConfigObject(obj interface{}, initializeGSLBMemberClusters Initializ
 	// check if the controller details provided are for a leader site
 	isLeader, err := avicache.IsAviSiteLeader()
 	if err != nil {
-		gslbutils.Errf("error fetching Gslb leader site details, %s", err.Error())
-		return
+		errMsg := fmt.Sprintf("error fetching Gslb leader site details, %s", err.Error())
+		gslbutils.UpdateGSLBConfigStatus(errMsg)
+		gslbutils.Errf(errMsg)
+		panic(errMsg)
 	}
 	if !isLeader {
 		gslbutils.Errf("Controller details provided are not for a leader, returning")
 		gslbutils.UpdateGSLBConfigStatus(ControllerNotLeaderMsg)
 		gslbutils.SetControllerAsFollower()
-		return
 	}
 	gslbutils.SetControllerAsLeader()
 


### PR DESCRIPTION
Currently, federator always logs the info/warnings/errors to the default
console. This commit enables external logging if USE_PVC is set to
"true". We initialize an external log writer and assign it to the
controller runtime's logger.

Additionally, this PR also adds a panic for AMKO if it gets an error
while fetching the GSLB details from a controller.