### PR TITLE
Fix parsing error for TTL value for a REST response

### DIFF
--- a/gslb/cache/controller_obj_cache.go
+++ b/gslb/cache/controller_obj_cache.go
@@ -718,9 +718,15 @@ func GetDetailsFromAviGSLB(gslbSvcMap map[string]interface{}) (uint32, []GSMembe
 		persistenceProfileRefPtr = &persistenceProfileRef
 	}
 
-	ttlVal, ok := gslbSvcMap["ttl"].(int)
+	ttlVal, ok := gslbSvcMap["ttl"]
 	if ok {
-		ttl = &ttlVal
+		parsedValF, ok := ttlVal.(float64)
+		if ok {
+			parsedValI := int(parsedValF)
+			ttl = &parsedValI
+		} else {
+			gslbutils.Errf("couldn't parse the ttl value: %v", ttlVal)
+		}
 	}
 
 	var poolAlgorithmSettings *gslbalphav1.PoolAlgorithmSettings


### PR DESCRIPTION
This fixes a bug where the checksum doesn't change for the GS cache
update operation, as the response is not parsed properly for the
`ttl` value. Whatever the ttl value, we always set it to `nil` before
calculating the checksum of the GS obtained from the REST response.

This doesn't happen during bootup (as AMKO takes another path), but
during POST/PUT operations for a GS.