### PR TITLE
Fix validation of current AMKOCluster object while AMKO bootup

### DIFF
--- a/federator/controllers/amkocluster_controller.go
+++ b/federator/controllers/amkocluster_controller.go
@@ -165,7 +165,7 @@ func (r *AMKOClusterReconciler) FetchMemberClusterContextsAndUpdateStatus(ctx co
 func (r *AMKOClusterReconciler) ValidateAMKOClusterSanityAndUpdateStatus(ctx context.Context,
 	amkoCluster *amkov1alpha1.AMKOCluster) error {
 
-	err := r.VerifyAMKOClusterSanity(amkoCluster)
+	err := VerifyAMKOClusterSanity(amkoCluster)
 	if err != nil {
 		if statusErr := r.UpdateAMKOClusterStatus(ctx, CurrentAMKOClusterValidationStatusType,
 			StatusMsgInvalidAMKOCluster, err.Error(), nil, amkoCluster); statusErr != nil {
@@ -343,24 +343,6 @@ func (r *AMKOClusterReconciler) FetchMemberClusterContexts(ctx context.Context, 
 	}
 
 	return memberClusters, errClusters, nil
-}
-
-func (r *AMKOClusterReconciler) VerifyAMKOClusterSanity(amkoCluster *amkov1alpha1.AMKOCluster) error {
-	log.Log.V(1).Info("Performing sanity checks on AMKOCluster object")
-	// namespace for AMKOCluster object has to be avi-system
-	if amkoCluster.Namespace != AviSystemNS {
-		return fmt.Errorf("AMKOCluster's namespace is not %s", AviSystemNS)
-	}
-	// check the current context
-	if amkoCluster.Spec.ClusterContext == "" {
-		return fmt.Errorf("clusterContext field can't be empty in AMKOCluster object")
-	}
-	// check the version field
-	if amkoCluster.Spec.Version == "" {
-		return fmt.Errorf("version field can't be empty in AMKOCluster object")
-	}
-
-	return nil
 }
 
 func (r *AMKOClusterReconciler) UpdateStatus(updatedAMKOCluster *amkov1alpha1.AMKOCluster) {

--- a/federator/controllers/utils.go
+++ b/federator/controllers/utils.go
@@ -515,3 +515,21 @@ func InitMemberClusterContexts(ctx context.Context, currentContext string,
 	}
 	return resClusters, errClusters, nil
 }
+
+func VerifyAMKOClusterSanity(amkoCluster *amkov1alpha1.AMKOCluster) error {
+	log.Log.V(1).Info("Performing sanity checks on AMKOCluster object")
+	// namespace for AMKOCluster object has to be avi-system
+	if amkoCluster.Namespace != AviSystemNS {
+		return fmt.Errorf("AMKOCluster's namespace is not %s", AviSystemNS)
+	}
+	// check the current context
+	if amkoCluster.Spec.ClusterContext == "" {
+		return fmt.Errorf("clusterContext field can't be empty in AMKOCluster object")
+	}
+	// check the version field
+	if amkoCluster.Spec.Version == "" {
+		return fmt.Errorf("version field can't be empty in AMKOCluster object")
+	}
+
+	return nil
+}

--- a/gslb/ingestion/bootup_handler.go
+++ b/gslb/ingestion/bootup_handler.go
@@ -115,6 +115,12 @@ func (r *AMKOClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
+	// verify the basic sanity of the AMKOCluster object
+	if err := federator.VerifyAMKOClusterSanity(&amkoCluster); err != nil {
+		gslbutils.Errf("validation of AMKOCluster object failed with error: %v", err)
+		return ctrl.Result{}, err
+	}
+
 	memberClusters, errClusters, err := federator.FetchMemberClusterContexts(ctx, amkoCluster.DeepCopy())
 	if err != nil {
 		gslbutils.Warnf("Error in fetching member cluster contexts: %v", err)
@@ -188,6 +194,11 @@ func HandleBootup(cfg *restclient.Config) (bool, error) {
 	} else {
 		gslbutils.Logf("AMKOCluster object found and AMKO would start as follower")
 		return false, nil
+	}
+
+	// verify the basic sanity of the AMKOCluster object
+	if err := federator.VerifyAMKOClusterSanity(&amkoCluster); err != nil {
+		return false, err
 	}
 
 	memberClusters, errClusters, err := federator.FetchMemberClusterContexts(context.TODO(), amkoCluster.DeepCopy())

--- a/gslb/test/bootuptest/bootup_test.go
+++ b/gslb/test/bootuptest/bootup_test.go
@@ -207,6 +207,7 @@ func getTestAMKOClusterObj(currentContext string, isLeader bool) amkovmwarecomv1
 			ClusterContext: currentContext,
 			IsLeader:       isLeader,
 			Clusters:       []string{Cluster1, Cluster2},
+			Version:        TestAMKOVersion,
 		},
 	}
 }


### PR DESCRIPTION
Currently we don't validate the sanity of the current cluster's
AMKOCluster object while AMKO is booting up. This commit moves the
validation function to utils and AMKO bootup now validates the
sanity.