### PR TITLE
Update the health monitor path names only if no references

### DIFF
--- a/gslb/cache/controller_obj_cache.go
+++ b/gslb/cache/controller_obj_cache.go
@@ -558,11 +558,13 @@ func ParsePoolAlgorithmSettingsFromPoolRaw(group map[string]interface{}) *gslbal
 	} else {
 		fallbackAlgorithm = &f
 	}
-	c, ok := group["consistent_hash_mask"].(int32)
-	if !ok {
-		gslbutils.Debugf("couldn't parse hash mask: %v", group)
+
+	hashMaskF, ok := group["consistent_hash_mask"].(float64)
+	if ok {
+		hashMaskI := int32(hashMaskF)
+		consistentHashMask = &hashMaskI
 	} else {
-		consistentHashMask = &c
+		gslbutils.Errf("couldn't parse hash mask: %v", group["consistent_hash_mask"])
 	}
 
 	return ParsePoolAlgorithmSettings(algorithm, fallbackAlgorithm, consistentHashMask)

--- a/gslb/nodes/avi_model_nodes.go
+++ b/gslb/nodes/avi_model_nodes.go
@@ -564,10 +564,13 @@ func (v *AviGSObjectGraph) AddUpdateGSMember(newMember AviGSK8sObj) bool {
 	}
 
 	v.MemberObjs = append(v.MemberObjs, newMember)
-	if newMember.ObjType == gslbutils.SvcType || newMember.IsPassthrough {
-		v.checkAndUpdateNonPathHealthMonitor(newMember.ObjType, newMember.IsPassthrough)
-	} else {
-		v.updateGSHmPathListAndProtocol()
+	if v.HmRefs == nil || len(v.HmRefs) == 0 {
+		// update the health monitors if hm refs is not nil or non-zero
+		if newMember.ObjType == gslbutils.SvcType || newMember.IsPassthrough {
+			v.checkAndUpdateNonPathHealthMonitor(newMember.ObjType, newMember.IsPassthrough)
+		} else {
+			v.updateGSHmPathListAndProtocol()
+		}
 	}
 	return false
 }


### PR DESCRIPTION
Currently, when we add a new member in the GS graph pool, we
re-construct the health monitor path list unconditionally. While we do
have a check in layer 3 to make sure that we give priority to the
health monitor references in the `GDP` or `GSLBHostRule` objects, this
can cause unnecessary updates to the GSs in the controller. We
should update the HM paths only if there are no health monitor
references present in the `GDP` or `GSLBHostRule` objects.