### PR TITLE
Don't update status if status already reflects that AMKO needs a reboot

### DIFF
--- a/gslb/gslbutils/gslbutils.go
+++ b/gslb/gslbutils/gslbutils.go
@@ -326,6 +326,12 @@ func UpdateGSLBConfigStatus(msg string) error {
 		return nil
 	}
 
+	// ensure that once the GSLBConfig object has been updated and the status already reflects
+	// that, no other status updates can be done unless AMKO is rebooted
+	if GetGslbConfigObjUpdated() {
+		Logf("GSLBConfig object has been updated, AMKO reboot is required")
+		return nil
+	}
 	updateGSLBConfigStatusMsg(msg)
 	gcStatus := gslbalphav1.GSLBConfigStatus{
 		State: msg,
@@ -645,4 +651,17 @@ func GetUriFromAvi(uri string, aviClient *clients.AviClient, infiniteRetry bool)
 func LogAndPanic(panicMsg string) {
 	Errf(panicMsg)
 	panic(panicMsg)
+}
+
+var gslbConfigObjUpdated bool
+var updatedOnce sync.Once
+
+func SetGslbConfigObjUpdated(value bool) {
+	updatedOnce.Do(func() {
+		gslbConfigObjUpdated = true
+	})
+}
+
+func GetGslbConfigObjUpdated() bool {
+	return gslbConfigObjUpdated
 }

--- a/gslb/ingestion/gslb.go
+++ b/gslb/ingestion/gslb.go
@@ -251,6 +251,7 @@ func GetNewController(kubeclientset kubernetes.Interface, gslbclientset gslbcs.I
 			}
 			gslbutils.Warnf("an update has been made to the GSLBConfig object, AMKO needs a reboot to register the changes")
 			gslbutils.UpdateGSLBConfigStatus(EditRestartMsg)
+			gslbutils.SetGSLBConfig(true)
 		},
 	})
 	return gslbController


### PR DESCRIPTION
Currently, if there's an update to the `GSLBConfig` object, the status
reflects that AMKO needs a reboot since the `GSLBConfig` object got
updated. Meanwhile, if the object had a controller IP which was GSLB
leader previously and got changed to follower, the resync goroutine
determines this and overwrites the status reflecting that the controller
IP provided is not of a leader. This fixes the overwrite issue and
always reflects that AMKO needs a reboot once the `GSLBConfig` object
gets updated.