### PR TITLE
Shutdown API server if the GSLB leader IP is changed

### DIFF
--- a/gslb/ingestion/gslb.go
+++ b/gslb/ingestion/gslb.go
@@ -246,6 +246,12 @@ func GetNewController(kubeclientset kubernetes.Interface, gslbclientset gslbcs.I
 				}
 			}
 
+			if oldGc.Spec.GSLBLeader.ControllerIP != newGc.Spec.GSLBLeader.ControllerIP {
+				gslbutils.Warnf("GSLB Leader IP has changed, will restart")
+				apiserver.GetAmkoAPIServer().ShutDown()
+				return
+			}
+
 			if getGSLBConfigChecksum(oldGc) == getGSLBConfigChecksum(newGc) {
 				return
 			}


### PR DESCRIPTION
Currently, AMKO needs a reboot if any field other than `logLevel`
is updated. This commit shuts down the API server, as soon as the
leader IP is changed in the `GSLBConfig` object, prompting kubernetes
to restart the pod.