### PR TITLE
Health Monitor name encoding

### DIFF
--- a/gslb/cache/controller_obj_cache.go
+++ b/gslb/cache/controller_obj_cache.go
@@ -52,6 +52,7 @@ type AviHmObj struct {
 	UUID             string
 	Type             string
 	CloudConfigCksum uint32
+	Description      string
 }
 
 type AviHmCache struct {
@@ -182,13 +183,18 @@ func (h *AviHmCache) AviHmObjCachePopulate(client *clients.AviClient, hmname ...
 			if hm.MonitorPort != nil {
 				monitorPort = *hm.MonitorPort
 			}
-			cksum := gslbutils.GetGSLBHmChecksum(*hm.Name, *hm.Type, monitorPort)
+			description := ""
+			if hm.Description != nil {
+				description = *hm.Description
+			}
+			cksum := gslbutils.GetGSLBHmChecksum(*hm.Type, monitorPort, []string{description})
 			hmCacheObj := AviHmObj{
 				Name:             *hm.Name,
 				Tenant:           utils.ADMIN_NS,
 				UUID:             *hm.UUID,
 				Port:             monitorPort,
 				CloudConfigCksum: cksum,
+				Description:      description,
 			}
 			h.AviHmCacheAdd(k, &hmCacheObj)
 			gslbutils.Debugf("processed health monitor %s", *hm.Name)
@@ -321,14 +327,19 @@ type GSMember struct {
 	Controller string
 }
 
+type HealthMonitorDetails struct {
+	HealthMonitorNames       string
+	HealthMonitorDescription string
+}
+
 type AviGSCache struct {
-	Name               string
-	Tenant             string
-	Uuid               string
-	Members            []GSMember
-	K8sObjects         []string
-	HealthMonitorNames []string
-	CloudConfigCksum   uint32
+	Name             string
+	Tenant           string
+	Uuid             string
+	Members          []GSMember
+	K8sObjects       []string
+	HealthMonitor    []HealthMonitorDetails
+	CloudConfigCksum uint32
 }
 
 type AviCache struct {
@@ -470,13 +481,13 @@ func parseGSObject(c *AviCache, gsObj models.GslbService, gsname []string) {
 	}
 	k := TenantName{Tenant: utils.ADMIN_NS, Name: name}
 	gsCacheObj := AviGSCache{
-		Name:               name,
-		Tenant:             utils.ADMIN_NS,
-		Uuid:               uuid,
-		Members:            gsMembers,
-		K8sObjects:         memberObjs,
-		HealthMonitorNames: hms,
-		CloudConfigCksum:   cksum,
+		Name:             name,
+		Tenant:           utils.ADMIN_NS,
+		Uuid:             uuid,
+		Members:          gsMembers,
+		K8sObjects:       memberObjs,
+		HealthMonitor:    hms,
+		CloudConfigCksum: cksum,
 	}
 	c.AviCacheAdd(k, &gsCacheObj)
 	gslbutils.Debugf(spew.Sprintf("cacheKey: %v, value: %v, msg: added GS to the cache", k,
@@ -571,8 +582,17 @@ func ParsePoolAlgorithmSettingsFromPoolRaw(group map[string]interface{}) *gslbal
 	return ParsePoolAlgorithmSettings(algorithm, fallbackAlgorithm, consistentHashMask)
 }
 
-func GetDetailsFromAviGSLBFormatted(gsObj models.GslbService) (uint32, []GSMember, []string, []string, error) {
-	var serverList, domainList, memberObjs, hms []string
+func GetHmNameList(hmList []HealthMonitorDetails) []string {
+	var hmNameList []string
+	for _, hm := range hmList {
+		hmNameList = append(hmNameList, hm.HealthMonitorNames)
+	}
+	return hmNameList
+}
+
+func GetDetailsFromAviGSLBFormatted(gsObj models.GslbService) (uint32, []GSMember, []string, []HealthMonitorDetails, error) {
+	var serverList, domainList, memberObjs []string
+	var hms []HealthMonitorDetails
 	var gsMembers []GSMember
 	var persistenceProfileRef string
 	var persistenceProfileRefPtr *string
@@ -581,7 +601,7 @@ func GetDetailsFromAviGSLBFormatted(gsObj models.GslbService) (uint32, []GSMembe
 
 	domainNames := gsObj.DomainNames
 	if len(domainNames) == 0 {
-		return 0, nil, memberObjs, hms, errors.New("domain names absent in gslb service")
+		return 0, nil, memberObjs, nil, errors.New("domain names absent in gslb service")
 	}
 	// make a copy of the domain names list
 	for _, domain := range domainNames {
@@ -590,19 +610,19 @@ func GetDetailsFromAviGSLBFormatted(gsObj models.GslbService) (uint32, []GSMembe
 
 	groups := gsObj.Groups
 	if len(groups) == 0 {
-		return 0, nil, memberObjs, hms, errors.New("groups absent in gslb service")
+		return 0, nil, memberObjs, nil, errors.New("groups absent in gslb service")
 	}
 
 	description := *gsObj.Description
 	if description == "" {
-		return 0, nil, memberObjs, hms, errors.New("description absent in gslb service")
+		return 0, nil, memberObjs, nil, errors.New("description absent in gslb service")
 	}
 
 	hmRefs := gsObj.HealthMonitorRefs
 	for _, hmRef := range hmRefs {
 		hmRefSplit := strings.Split(hmRef, "/api/healthmonitor/")
 		if len(hmRefSplit) != 2 {
-			return 0, nil, memberObjs, hms, errors.New("health monitor name is absent in health monitor ref: " + hmRefs[0])
+			return 0, nil, memberObjs, nil, errors.New("health monitor name is absent in health monitor ref: " + hmRefs[0])
 		}
 		hmUUID := hmRefSplit[1]
 		hmCache := GetAviHmCache()
@@ -616,7 +636,10 @@ func GetDetailsFromAviGSLBFormatted(gsObj models.GslbService) (uint32, []GSMembe
 			gslbutils.Debugf("gsName: %s, msg: health monitor cache object can't be parsed", *gsObj.Name)
 			continue
 		}
-		hm := hmObj.Name
+		hm := HealthMonitorDetails{
+			HealthMonitorNames:       hmObj.Name,
+			HealthMonitorDescription: hmObj.Description,
+		}
 		hms = append(hms, hm)
 	}
 
@@ -702,13 +725,51 @@ func GetDetailsFromAviGSLBFormatted(gsObj models.GslbService) (uint32, []GSMembe
 		gslbutils.Errf("object: GSLBService, msg: error while parsing description field: %s", err)
 	}
 	// calculate the checksum
-	checksum := gslbutils.GetGSLBServiceChecksum(serverList, domainList, memberObjs, hms,
+	checksum := gslbutils.GetGSLBServiceChecksum(serverList, domainList, memberObjs, GetHmNameList(hms),
 		persistenceProfileRefPtr, ttl, poolAlgorithmSettings)
 	return checksum, gsMembers, memberObjs, hms, nil
 }
 
-func GetDetailsFromAviGSLB(gslbSvcMap map[string]interface{}) (uint32, []GSMember, []string, []string, error) {
-	var serverList, domainList, memberObjs, hms []string
+// As name is encoded, retreiving information about the Hm becomes difficult
+// Thats why we fetch Hm description for further processing
+func GetHmDescriptionFromName(hmName string) string {
+	aviRestClientPool := SharedAviClients()
+	if len(aviRestClientPool.AviClient) < 1 {
+		return ""
+	}
+	uri := "/api/healthmonitor?name=" + hmName
+	result, err := gslbutils.GetUriFromAvi(uri, aviRestClientPool.AviClient[0], false)
+	if err != nil {
+		return ""
+	}
+
+	elems := make([]json.RawMessage, result.Count)
+	err = json.Unmarshal(result.Results, &elems)
+	if err != nil {
+		return ""
+	}
+	hmDescription := ""
+	for i := 0; i < len(elems); i++ {
+		hm := models.HealthMonitor{}
+		err = json.Unmarshal(elems[i], &hm)
+		if err != nil {
+			continue
+		}
+		if hm.Name == nil || hm.UUID == nil {
+			continue
+		}
+
+		if hm.Description != nil {
+			hmDescription = *hm.Description
+			break
+		}
+	}
+	return hmDescription
+}
+
+func GetDetailsFromAviGSLB(gslbSvcMap map[string]interface{}) (uint32, []GSMember, []string, []HealthMonitorDetails, error) {
+	var serverList, domainList, memberObjs []string
+	var hms []HealthMonitorDetails
 	var gsMembers []GSMember
 	var ttl *int
 
@@ -738,7 +799,11 @@ func GetDetailsFromAviGSLB(gslbSvcMap map[string]interface{}) (uint32, []GSMembe
 				errStr := fmt.Sprintf("health monitor name is absent in health monitor ref: %v", hmRefSplit[0])
 				return 0, nil, memberObjs, hms, errors.New(errStr)
 			}
-			hm := hmRefSplit[1]
+			hmDescription := GetHmDescriptionFromName(hmRefSplit[1])
+			hm := HealthMonitorDetails{
+				HealthMonitorNames:       hmRefSplit[1],
+				HealthMonitorDescription: hmDescription,
+			}
 			hms = append(hms, hm)
 		}
 	} else {
@@ -846,7 +911,7 @@ func GetDetailsFromAviGSLB(gslbSvcMap map[string]interface{}) (uint32, []GSMembe
 		gslbutils.Errf("object: GSLBService, msg: error while parsing description field: %s", err)
 	}
 	// calculate the checksum
-	checksum := gslbutils.GetGSLBServiceChecksum(serverList, domainList, memberObjs, hms,
+	checksum := gslbutils.GetGSLBServiceChecksum(serverList, domainList, memberObjs, GetHmNameList(hms),
 		persistenceProfileRefPtr, ttl, poolAlgorithmSettings)
 	return checksum, gsMembers, memberObjs, hms, nil
 }

--- a/gslb/cache/controller_obj_cache.go
+++ b/gslb/cache/controller_obj_cache.go
@@ -740,12 +740,14 @@ func GetHmDescriptionFromName(hmName string) string {
 	uri := "/api/healthmonitor?name=" + hmName
 	result, err := gslbutils.GetUriFromAvi(uri, aviRestClientPool.AviClient[0], false)
 	if err != nil {
+		gslbutils.Logf("error getting hm data, err : %v", err)
 		return ""
 	}
 
 	elems := make([]json.RawMessage, result.Count)
 	err = json.Unmarshal(result.Results, &elems)
 	if err != nil {
+		gslbutils.Logf("error unmarshalling hm data, err : %v", err)
 		return ""
 	}
 	hmDescription := ""

--- a/gslb/gslbutils/gslbutils.go
+++ b/gslb/gslbutils/gslbutils.go
@@ -274,6 +274,7 @@ func GetGSLBServiceChecksum(serverList, domainList, memberObjs, hmNames []string
 func GetGSLBHmChecksum(hmType string, port int32, description []string) uint32 {
 	portStr := strconv.FormatInt(int64(port), 10)
 	checksum := utils.Hash(hmType) + utils.Hash(portStr)
+	sort.Strings(description)
 	for _, desc := range description {
 		checksum = checksum + utils.Hash(desc)
 	}
@@ -542,7 +543,7 @@ func GetHmTypeForTLS(tls bool) string {
 }
 
 func CheckNameLength(name string, prefixToExclude string) bool {
-	if len(name)-len(prefixToExclude) < 256 {
+	if len(name)+len(prefixToExclude) < 256 {
 		return true
 	}
 	return false
@@ -562,17 +563,6 @@ func HMCreatedByAMKO(hmName string) bool {
 		return true
 	}
 	return false
-}
-
-func GetEncodedGSFromHmName(hmName string) (string, error) {
-	// for path based hms
-	hmNameSplit := strings.Split(hmName, "--")
-	if len(hmNameSplit) == 4 {
-		return hmNameSplit[2], nil
-	} else if len(hmNameSplit) == 2 {
-		return hmNameSplit[1], nil
-	}
-	return "", errors.New("error in parsing gs name, unexpected format")
 }
 
 // HostRuleMeta stores a partial set of information stripped from the HostRule object,

--- a/gslb/ingestion/fullsync.go
+++ b/gslb/ingestion/fullsync.go
@@ -399,9 +399,9 @@ func GenerateModels(gsCache *avicache.AviCache) {
 			continue
 		}
 		tenant, hmName := hmKey.Tenant, hmKey.Name
-		gsName, err := gslbutils.GetEncodedGSFromHmName(hmName)
+		gsName, err := avicache.GetGSFromHmName(hmName)
 		if err != nil {
-			gslbutils.Debugf("key: %v, msg: can't get gs name from hm", hmKey)
+			gslbutils.Debugf("key: %v, msg: can't get gs name from hm, err : %v", hmKey, err)
 			continue
 		}
 		gsKey := tenant + "/" + gsName

--- a/gslb/ingestion/fullsync.go
+++ b/gslb/ingestion/fullsync.go
@@ -399,7 +399,7 @@ func GenerateModels(gsCache *avicache.AviCache) {
 			continue
 		}
 		tenant, hmName := hmKey.Tenant, hmKey.Name
-		gsName, err := gslbutils.GetGSFromHmName(hmName)
+		gsName, err := gslbutils.GetEncodedGSFromHmName(hmName)
 		if err != nil {
 			gslbutils.Debugf("key: %v, msg: can't get gs name from hm", hmKey)
 			continue

--- a/gslb/nodes/avi_model_nodes.go
+++ b/gslb/nodes/avi_model_nodes.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	createdbyamko = "created by: amko"
+	CreatedByAMKO = "created by: amko"
 )
 
 var aviGSGraphInstance *AviGSGraphLister
@@ -280,7 +280,7 @@ func (v *AviGSObjectGraph) BuildHmPathName(gsName, path string, isSec bool) Heal
 			GsName:      gsName,
 			Path:        path,
 			Protocol:    protocol,
-			Description: createdbyamko + ", gsname: " + gsName + ", path: " + path + ", protocol: " + protocol,
+			Description: CreatedByAMKO + ", gsname: " + gsName + ", path: " + path + ", protocol: " + protocol,
 		}
 		return hmPathDescription
 	}
@@ -318,7 +318,7 @@ func (v *AviGSObjectGraph) BuildNonPathHmName(gsName string) string {
 	encodedHMName := gslbutils.EncodeHMName(gsName)
 	prefix := "amko--"
 	if gslbutils.CheckNameLength(encodedHMName, prefix) {
-		v.Hm.Description = createdbyamko + ", gsname: " + gsName
+		v.Hm.Description = CreatedByAMKO + ", gsname: " + gsName
 		return prefix + encodedHMName
 	}
 	gslbutils.Errf("hm: %s, msg: hm name could not be encoded", gsName)

--- a/gslb/nodes/dq_ingestion.go
+++ b/gslb/nodes/dq_ingestion.go
@@ -143,6 +143,17 @@ func PublishAllGraphKeys() {
 	}
 }
 
+func GetHmChecksum(objType string, gsGraph *AviGSObjectGraph) uint32 {
+	var checksum uint32
+	if objType == gslbutils.SvcType {
+		checksum = gsGraph.GetHmChecksum([]string{gsGraph.Hm.Description})
+	} else {
+		description := GetDescriptionListForPathHms(gsGraph.Hm.PathNames)
+		checksum = gsGraph.GetHmChecksum(description)
+	}
+	return checksum
+}
+
 func AddUpdateGSLBHostRuleOperation(key, objType, objName string, wq *utils.WorkerQueue, agl *AviGSGraphLister) {
 	modelName := utils.ADMIN_NS + "/" + objName
 	found, aviGS := agl.Get(modelName)
@@ -152,12 +163,12 @@ func AddUpdateGSLBHostRuleOperation(key, objType, objName string, wq *utils.Work
 		return
 	}
 	gsGraph := aviGS.(*AviGSObjectGraph)
-	prevHmChecksum := gsGraph.GetHmChecksum()
+	prevHmChecksum := GetHmChecksum(objType, gsGraph)
 	prevChecksum := gsGraph.GetChecksum()
 	// update the GS graph
 	aviGS.(*AviGSObjectGraph).UpdateAviGSGraphWithGSFqdn(objName, false, gsGraph.MemberObjs[0].TLS)
 	newChecksum := gsGraph.GetChecksum()
-	newHmChecksum := gsGraph.GetHmChecksum()
+	newHmChecksum := GetHmChecksum(objType, gsGraph)
 	gslbutils.Debugf("prevChecksum: %d, newChecksum: %d, prevHmChecksum: %d, newHmChecksum: %d, key: %s", prevChecksum,
 		newChecksum, prevHmChecksum, newHmChecksum, key)
 	if (prevChecksum == newChecksum) && (prevHmChecksum == newHmChecksum) {
@@ -254,14 +265,14 @@ func AddUpdateObjOperation(key, cname, ns, objType, objName string, wq *utils.Wo
 		agl.Save(modelName, aviGS.(*AviGSObjectGraph))
 	} else {
 		gsGraph := aviGS.(*AviGSObjectGraph)
-		prevHmChecksum := gsGraph.GetHmChecksum()
+		prevHmChecksum := GetHmChecksum(objType, gsGraph)
 		// since the object was found, fetch the current checksum
 		prevChecksum = gsGraph.GetChecksum()
 		// Update the member of the GSGraph's GSNode
 		aviGS.(*AviGSObjectGraph).UpdateGSMemberFromMetaObj(metaObj)
 		// Get the new checksum after the updates
 		newChecksum = gsGraph.GetChecksum()
-		newHmChecksum := gsGraph.GetHmChecksum()
+		newHmChecksum := GetHmChecksum(objType, gsGraph)
 
 		gslbutils.Debugf("prevChecksum: %d, newChecksum: %d, prevHmChecksum: %d, newHmChecksum: %d, key: %s", prevChecksum,
 			newChecksum, prevHmChecksum, newHmChecksum, key)

--- a/gslb/nodes/dq_ingestion.go
+++ b/gslb/nodes/dq_ingestion.go
@@ -146,9 +146,9 @@ func PublishAllGraphKeys() {
 func GetHmChecksum(objType string, gsGraph *AviGSObjectGraph) uint32 {
 	var checksum uint32
 	if objType == gslbutils.SvcType {
-		checksum = gsGraph.GetHmChecksum([]string{gsGraph.Hm.Description})
+		checksum = gsGraph.GetHmChecksum(gsGraph.Hm.GetHMDescription(gsGraph.Name))
 	} else {
-		description := GetDescriptionListForPathHms(gsGraph.Hm.PathNames)
+		description := gsGraph.Hm.GetHMDescription(gsGraph.Name)
 		checksum = gsGraph.GetHmChecksum(description)
 	}
 	return checksum

--- a/gslb/nodes/node_utils.go
+++ b/gslb/nodes/node_utils.go
@@ -185,9 +185,9 @@ func updateThirdPartyMembers(gsGraph *AviGSObjectGraph, thirdPartyMembers []v1al
 	gslbutils.Logf("gslb members: %v", gsGraph.MemberObjs)
 }
 
-func PresentInHealthMonitorPathList(key string, hmPathList []HealthMonitorPathDescription) bool {
-	for _, path := range hmPathList {
-		if path.Description == key {
+func PresentInHealthMonitorPathList(key PathHealthMonitorDetails, pathHmList []PathHealthMonitorDetails) bool {
+	for _, pathHM := range pathHmList {
+		if pathHM.Path == key.Path && pathHM.IngressProtocol == key.IngressProtocol {
 			return true
 		}
 	}
@@ -195,16 +195,16 @@ func PresentInHealthMonitorPathList(key string, hmPathList []HealthMonitorPathDe
 }
 
 func GetDescriptionForPathHMName(hmName string, gsMeta *AviGSObjectGraph) string {
-	for _, pathnames := range gsMeta.Hm.PathNames {
-		if pathnames.HmName == hmName {
-			return pathnames.Description
+	for _, pathnames := range gsMeta.Hm.PathHM {
+		if pathnames.Name == hmName {
+			return pathnames.GetPathHMDescription(gsMeta.Name)
 		}
 	}
-	gslbutils.Warnf("hmName: %s, msg: cannot find path description", hmName)
+	gslbutils.Warnf("hmName: %s, msg: cannot find description for health monitor", hmName)
 	return ""
 }
 
-func GetHMPathFromDescription(hmName, hmDescription string) string {
+func GetPathFromHmDescription(hmName, hmDescription string) string {
 	hmDescriptionSplit := strings.Split(hmDescription, ": ")
 	if len(hmDescriptionSplit) != 5 {
 		gslbutils.Warnf("hmName: %s, msg: hm description - \"%s\" is malformed, expected a path based hm", hmName, hmDescription)
@@ -215,18 +215,10 @@ func GetHMPathFromDescription(hmName, hmDescription string) string {
 	return hmPath
 }
 
-func GetDescriptionListForPathHms(pathname []HealthMonitorPathDescription) []string {
-	var descriptionList []string
-	for _, paths := range pathname {
-		descriptionList = append(descriptionList, paths.Description)
-	}
-	return descriptionList
-}
-
-func GetHmNameListFromPathNames(pathname []HealthMonitorPathDescription) []string {
+func GetPathHmNameList(hm HealthMonitor) []string {
 	var hmNameList []string
-	for _, path := range pathname {
-		hmNameList = append(hmNameList, path.HmName)
+	for _, path := range hm.PathHM {
+		hmNameList = append(hmNameList, path.Name)
 	}
 	return hmNameList
 }

--- a/gslb/nodes/node_utils.go
+++ b/gslb/nodes/node_utils.go
@@ -184,3 +184,41 @@ func updateThirdPartyMembers(gsGraph *AviGSObjectGraph, thirdPartyMembers []v1al
 	}
 	gslbutils.Logf("gslb members: %v", gsGraph.MemberObjs)
 }
+
+func PresentInHealthMonitorPathList(key string, hmPathList []HealthMonitorPathDescription) bool {
+	for _, path := range hmPathList {
+		if path.Description == key {
+			return true
+		}
+	}
+	return false
+}
+
+func GetDescriptionForPathHMName(hmName string, gsMeta *AviGSObjectGraph) string {
+	for _, pathnames := range gsMeta.Hm.PathNames {
+		if pathnames.HmName == hmName {
+			return pathnames.Description
+		}
+	}
+	gslbutils.Warnf("hmName: %s, msg: cannot find path description", hmName)
+	return ""
+}
+
+func GetHMPathFromDescription(hmName, hmDescription string) string {
+	hmDescriptionSplit := strings.Split(hmDescription, ": ")
+	if len(hmDescriptionSplit) != 5 {
+		gslbutils.Warnf("hmName: %s, msg: hm description - \"%s\" is malformed, expected a path based hm", hmName, hmDescription)
+		return ""
+	}
+	hmPathField := strings.Split(hmDescriptionSplit[3], ",")
+	hmPath := strings.Trim(hmPathField[0], " ")
+	return hmPath
+}
+
+func GetDescriptionListForPathHms(pathname []HealthMonitorPathDescription) []string {
+	var descriptionList []string
+	for _, paths := range pathname {
+		descriptionList = append(descriptionList, paths.Description)
+	}
+	return descriptionList
+}

--- a/gslb/nodes/node_utils.go
+++ b/gslb/nodes/node_utils.go
@@ -222,3 +222,11 @@ func GetDescriptionListForPathHms(pathname []HealthMonitorPathDescription) []str
 	}
 	return descriptionList
 }
+
+func GetHmNameListFromPathNames(pathname []HealthMonitorPathDescription) []string {
+	var hmNameList []string
+	for _, path := range pathname {
+		hmNameList = append(hmNameList, path.HmName)
+	}
+	return hmNameList
+}

--- a/gslb/test/avimockobjects/hm_mock.json
+++ b/gslb/test/avimockobjects/hm_mock.json
@@ -1,5 +1,5 @@
 {
-    "count": 17,
+    "count": 25,
     "results": [
       {
         "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-d0a4d080-323e-495e-b010-bb12bd8fe94e",
@@ -321,6 +321,118 @@
         "successful_checks": 2,
         "failed_checks": 2,
         "type": "HEALTH_MONITOR_HTTPS"
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-6837ea95-7613-7865-a059-b6exxxxx",
+        "uuid" : "amko--74020be7ae3cb31790e74f2efe5dfbef4d36b090",
+        "name": "amko--74020be7ae3cb31790e74f2efe5dfbef4d36b090",
+        "is_federated": true,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1616766136533179",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_HTTPS",
+        "description" : "created by: amko, gsname: tdr-host1.avi.com, path: /, protocol: http"
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-6837ea95-7613-7865-a059-b6exxxxx",
+        "uuid" : "amko--404a2d006d4cdbd9eb76a3cd2af969ab2a09508b",
+        "name": "amko--404a2d006d4cdbd9eb76a3cd2af969ab2a09508b",
+        "is_federated": true,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1616766136533179",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_HTTPS",
+        "description" : "created by: amko, gsname: hm-cir-host1.avi.com, path: /, protocol: https"
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-6837ea95-7613-7865-a059-b6e34c39f321",
+        "uuid": "amko--a4b855c3f1b8c2374cbb0c9fcf271df96bdbfa1d",
+        "name": "amko--a4b855c3f1b8c2374cbb0c9fcf271df96bdbfa1d",
+        "is_federated": true,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1616766136533179",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_HTTPS",
+        "description": "created by: amko, gsname: hm-cir-host1.avi.com, path: /foo, protocol: https"
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-6837ea95-7613-7865-a059-b6e34c39f321",
+        "uuid": "amko--93f554d69a24bba5a6fa9c736cef8e359b3ee12d",
+        "name": "amko--93f554d69a24bba5a6fa9c736cef8e359b3ee12d",
+        "is_federated": true,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1616766136533179",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_HTTPS",
+        "description": "created by: amko, gsname: hm-cir-host1.avi.com, path: /bar, protocol: https"
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-6837ea95-7613-7865-a059-b6e34c39f321",
+        "uuid": "amko--1fd9089ca176a8ea8bd31c07cb0a0a25d223042f",
+        "name": "amko--1fd9089ca176a8ea8bd31c07cb0a0a25d223042f",
+        "is_federated": true,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1616766136533179",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_HTTPS",
+        "description": "created by: amko, gsname: hm-cir-host1.avi.com, path: /foo1, protocol: https"
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-6837ea95-7613-7865-a059-b6e34c39f321",
+        "uuid": "amko--d6815c2b23b45186a1bdd34c6aeac5ff293558ee",
+        "name": "amko--d6815c2b23b45186a1bdd34c6aeac5ff293558ee",
+        "is_federated": true,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1616766136533179",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_HTTPS",
+        "description": "created by: amko, gsname: hm-cir-host1.avi.com, path: /bar1, protocol: https"
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-6837ea95-7613-7865-a059-b6e34c39f321",
+        "uuid": "amko--2765cca2c7e6ee9b5a317165917464e0cd4ef747",
+        "name": "amko--2765cca2c7e6ee9b5a317165917464e0cd4ef747",
+        "is_federated": true,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1616766136533179",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_HTTPS",
+        "description": "created by: amko, gsname: updated-hm-cir-host1.avi.com, path: /updatedPath, protocol: https"
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-6837ea95-7613-7865-a059-b6e34c39f321",
+        "uuid": "amko--77e58a6abc75aa11ac812c109251b0d2eaf18b03",
+        "name": "amko--77e58a6abc75aa11ac812c109251b0d2eaf18b03",
+        "is_federated": true,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1616766136533179",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_HTTPS",
+        "description": "created by: amko, gsname: hm-cir-svc.default.host1.avi.com"
       }
     ]
   }

--- a/gslb/test/avimockobjects/hm_mock.json
+++ b/gslb/test/avimockobjects/hm_mock.json
@@ -1,5 +1,5 @@
 {
-    "count": 25,
+    "count": 26,
     "results": [
       {
         "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-d0a4d080-323e-495e-b010-bb12bd8fe94e",
@@ -433,6 +433,20 @@
         "failed_checks": 2,
         "type": "HEALTH_MONITOR_HTTPS",
         "description": "created by: amko, gsname: hm-cir-svc.default.host1.avi.com"
+      },
+      {
+        "url": "https://10.79.110.246/api/healthmonitor/healthmonitor-6837ea95-7613-7865-a059-b6e34c39f321",
+        "uuid": "amko--1127702611a2a374109db10e4728b7f037b9d2cf",
+        "name": "amko--1127702611a2a374109db10e4728b7f037b9d2cf",
+        "is_federated": true,
+        "tenant_ref": "https://10.79.110.246/api/tenant/admin",
+        "_last_modified": "1616766136533179",
+        "send_interval": 10,
+        "receive_timeout": 4,
+        "successful_checks": 2,
+        "failed_checks": 2,
+        "type": "HEALTH_MONITOR_HTTPS",
+        "description": "created by: amko, gsname: tdrns-host1.avi.com, path: /, protocol: http"
       }
     ]
   }

--- a/gslb/test/integration/custom_fqdn/lib.go
+++ b/gslb/test/integration/custom_fqdn/lib.go
@@ -403,15 +403,15 @@ func verifyGSMembers(t *testing.T, expectedMembers []nodes.AviGSK8sObj, name, te
 	} else {
 		// default HM(s)
 		if tls {
-			if gs.Hm.Protocol != gslbutils.SystemGslbHealthMonitorHTTPS {
+			if gs.Hm.HMProtocol != gslbutils.SystemGslbHealthMonitorHTTPS {
 				t.Logf("hm protocol didn't match, expected: %s, got: %s", gslbutils.SystemGslbHealthMonitorHTTPS,
-					gs.Hm.Protocol)
+					gs.Hm.HMProtocol)
 				return false
 			}
 		} else {
-			if gs.Hm.Protocol != gslbutils.SystemGslbHealthMonitorHTTP {
+			if gs.Hm.HMProtocol != gslbutils.SystemGslbHealthMonitorHTTP {
 				t.Logf("hm protocol didn't match, expected: %s, got: %s", gslbutils.SystemGslbHealthMonitorHTTP,
-					gs.Hm.Protocol)
+					gs.Hm.HMProtocol)
 				return false
 			}
 		}

--- a/gslb/test/integration/third_party_vips/gslb_hostrule_test.go
+++ b/gslb/test/integration/third_party_vips/gslb_hostrule_test.go
@@ -121,9 +121,9 @@ func addIngressAndRouteObjects(t *testing.T, testPrefix string) (*networkingv1be
 	})
 
 	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
-		ingHostIPMap, true)
+		ingHostIPMap, defaultPath, TlsTrue)
 	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
-		routeCluster, host, routeIPAddr, true)
+		routeCluster, host, routeIPAddr, defaultPath[0], TlsTrue)
 	return ingObj, routeObj
 }
 
@@ -142,7 +142,8 @@ func TestGDPPropertiesForHealthMonitor(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, hmRefs, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, hmRefs, nil, nil, nil,
+			defaultPath, TlsTrue, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 	// Update the GDP object with a new health monitor ref
@@ -150,7 +151,8 @@ func TestGDPPropertiesForHealthMonitor(t *testing.T) {
 	newGDP.Spec.HealthMonitorRefs = []string{"my-hm2"}
 	updateTestGDP(t, newGDP)
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, hmRefs, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, hmRefs, nil, nil, nil,
+			defaultPath, TlsTrue, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }
 
@@ -191,7 +193,7 @@ func TestGDPPropertiesForPersistenceProfile(t *testing.T) {
 
 	g.Eventually(func() bool {
 		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, nil, &sitePersistence,
-			nil, nil)
+			nil, nil, defaultPath, TlsTrue, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }
 
@@ -211,7 +213,7 @@ func TestGDPPropertiesForTTL(t *testing.T) {
 
 	g.Eventually(func() bool {
 		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, nil, nil,
-			&ttl, nil)
+			&ttl, nil, defaultPath, TlsTrue, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 	t.Logf("Updating TTL value to 20 seconds")
@@ -222,7 +224,7 @@ func TestGDPPropertiesForTTL(t *testing.T) {
 
 	g.Eventually(func() bool {
 		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, nil, nil,
-			&ttl, nil)
+			&ttl, nil, defaultPath, TlsTrue, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }
 
@@ -245,7 +247,7 @@ func TestGDPPropertiesForPoolAlgorithm(t *testing.T) {
 
 	g.Eventually(func() bool {
 		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, nil, nil,
-			&ttl, &pa)
+			&ttl, &pa, defaultPath, TlsTrue, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 	t.Logf("Updating algorithm to GSLB_ALGORITHM_TOPOLOGY")
@@ -259,7 +261,7 @@ func TestGDPPropertiesForPoolAlgorithm(t *testing.T) {
 
 	g.Eventually(func() bool {
 		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, nil, nil,
-			&ttl, &pa)
+			&ttl, &pa, defaultPath, TlsTrue, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }
 
@@ -288,7 +290,7 @@ func TestGDPPropertiesForPoolAlgorithmCombinations(t *testing.T) {
 
 		g.Eventually(func() bool {
 			return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, nil, nil,
-				&ttl, &pa)
+				&ttl, &pa, defaultPath, TlsTrue, nil)
 		}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 	}
 
@@ -361,7 +363,7 @@ func TestGSLBHostRuleCreate(t *testing.T) {
 
 	g.Eventually(func() bool {
 		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, hmRefs, &sp,
-			&ttl, nil)
+			&ttl, nil, defaultPath, TlsTrue, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 	hostName := routeObj.Spec.Host
@@ -372,7 +374,7 @@ func TestGSLBHostRuleCreate(t *testing.T) {
 	g.Eventually(func() bool {
 		// Site persistence remains unchanged, as it inherits from the GDP object
 		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, gslbHRHmRefs,
-			&sp, &gslbHRTTL, nil)
+			&sp, &gslbHRTTL, nil, defaultPath, TlsTrue, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }
 
@@ -400,7 +402,7 @@ func TestGSLBHostRuleUpdate(t *testing.T) {
 	g.Eventually(func() bool {
 		// Site persistence remains unchanged, as it inherits from the GDP object
 		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, gslbHRHmRefs,
-			&sp, &gslbHRTTL, nil)
+			&sp, &gslbHRTTL, nil, defaultPath, TlsTrue, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 	// add a new site persistence
@@ -414,7 +416,7 @@ func TestGSLBHostRuleUpdate(t *testing.T) {
 	g.Eventually(func() bool {
 		// Site persistence changed and set to nil now
 		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, gslbHRHmRefs,
-			nil, &gslbHRTTL, nil)
+			nil, &gslbHRTTL, nil, defaultPath, TlsTrue, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 	// delete the health monitor ref from GSLB Host Rule and check if it is inherited from the
@@ -426,7 +428,7 @@ func TestGSLBHostRuleUpdate(t *testing.T) {
 	g.Eventually(func() bool {
 		// Health monitor refs are deleted, should be inherited from the GDP object
 		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, hmRefs,
-			nil, &gslbHRTTL, nil)
+			nil, &gslbHRTTL, nil, defaultPath, TlsTrue, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }
 
@@ -453,7 +455,7 @@ func TestGSLBHostRuleDelete(t *testing.T) {
 		ingestion.GslbHostRuleAccepted, "")
 	g.Eventually(func() bool {
 		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, gslbHRHmRefs,
-			&sp, &gslbHRTTL, nil)
+			&sp, &gslbHRTTL, nil, defaultPath, TlsTrue, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 	t.Logf("will delete the gslb host rule object")
@@ -461,7 +463,7 @@ func TestGSLBHostRuleDelete(t *testing.T) {
 	g.Eventually(func() bool {
 		// TTL and HM refs will fall back to the GDP object
 		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, hmRefs,
-			&sp, &ttl, nil)
+			&sp, &ttl, nil, defaultPath, TlsTrue, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }
 
@@ -482,7 +484,7 @@ func TestGSLBHostRuleCreateInvalidHM(t *testing.T) {
 
 	g.Eventually(func() bool {
 		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, hmRefs, &sp,
-			&ttl, nil)
+			&ttl, nil, defaultPath, TlsTrue, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 	hostName := routeObj.Spec.Host
@@ -493,7 +495,7 @@ func TestGSLBHostRuleCreateInvalidHM(t *testing.T) {
 	g.Eventually(func() bool {
 		// All fields remain unchanged because of the invalid GSLBHostRule
 		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, hmRefs,
-			&sp, &ttl, nil)
+			&sp, &ttl, nil, defaultPath, TlsTrue, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }
 
@@ -511,7 +513,8 @@ func TestGDPPropertiesForInvalidHealthMonitorUpdate(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, nil, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS,
+			nil, nil, nil, nil, defaultPath, TlsTrue, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 	// update GDP with valid and invalid hm refs
@@ -520,7 +523,8 @@ func TestGDPPropertiesForInvalidHealthMonitorUpdate(t *testing.T) {
 	gdp2 := updateTestGDPFailure(t, currGDP, "health monitor ref System-Ping is invalid")
 	g.Eventually(func() bool {
 		// member properties should remain unchanged
-		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, nil, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS,
+			nil, nil, nil, nil, defaultPath, TlsTrue, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 	// fix the hm refs
@@ -530,7 +534,8 @@ func TestGDPPropertiesForInvalidHealthMonitorUpdate(t *testing.T) {
 	updateTestGDP(t, gdp3)
 	g.Eventually(func() bool {
 		// member properties should now have the new health monitor refs
-		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, validRefs, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, validRefs,
+			nil, nil, nil, defaultPath, TlsTrue, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }
 
@@ -562,7 +567,7 @@ func TestGSLBHostRuleAlgorithmCombinations(t *testing.T) {
 
 		g.Eventually(func() bool {
 			return verifyGSMembers(t, expectedMembers, routeObj.Spec.Host, utils.ADMIN_NS, hmRefs, &sp,
-				&ttl, &pa)
+				&ttl, &pa, defaultPath, TlsTrue, nil)
 		}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 	}
 	verifyMembers(gdpPa)

--- a/gslb/test/integration/third_party_vips/health_monitor_test.go
+++ b/gslb/test/integration/third_party_vips/health_monitor_test.go
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package third_party_vips
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/nodes"
+	ingestion_test "github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/test/ingestion"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+)
+
+func TestHMAddIngressAndRoutes(t *testing.T) {
+	newGDP, err := BuildAddAndVerifyAppSelectorTestGDP(t)
+	if err != nil {
+		t.Fatalf("error in building, adding and verifying app selector GDP: %v", err)
+	}
+
+	testPrefix := "hm-cir-"
+	ingName := testPrefix + "ing"
+	routeName := testPrefix + "route"
+	ns := "default"
+	host := testPrefix + ingestion_test.TestDomain1
+	ingIPAddr := "1.1.1.1"
+	routeIPAddr := "2.2.2.2"
+	ingCluster := K8sContext
+	routeCluster := OshiftContext
+	ingHostIPMap := map[string]string{host: ingIPAddr}
+	path := []string{"/"}
+
+	t.Cleanup(func() {
+		k8sDeleteIngress(t, clusterClients[K8s], ingName, ns)
+		oshiftDeleteRoute(t, clusterClients[Oshift], routeName, ns)
+		DeleteTestGDP(t, newGDP.Namespace, newGDP.Name)
+	})
+
+	g := gomega.NewGomegaWithT(t)
+
+	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
+		ingHostIPMap, path, TlsTrue)
+	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
+		routeCluster, host, routeIPAddr, path[0], TlsTrue)
+
+	var expectedMembers []nodes.AviGSK8sObj
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
+
+	hmRefs := BuildTestPathHmNames(host, path, TlsTrue)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, hmRefs, nil, nil, nil, path, TlsTrue, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	g.Eventually(func() bool {
+		return verifyGSMembersInRestLayer(t, expectedMembers, host, utils.ADMIN_NS, hmRefs, nil, nil, nil, path, TlsTrue)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+func TestHMAddIngressAndRoutesMultiplePaths(t *testing.T) {
+	newGDP, err := BuildAddAndVerifyAppSelectorTestGDP(t)
+	if err != nil {
+		t.Fatalf("error in building, adding and verifying app selector GDP: %v", err)
+	}
+
+	testPrefix := "hm-cir-"
+	ingPaths := []string{"/foo", "/bar"}
+	ingName := testPrefix + "ing"
+	routePaths := []string{"/foo", "/bar1"}
+	routePrefix := testPrefix + "route"
+	var routeName []string
+	ns := "default"
+	host := testPrefix + ingestion_test.TestDomain1
+	ingIPAddr := "1.1.1.1"
+	routeIPAddr := "2.2.2.2"
+	ingCluster := K8sContext
+	routeCluster := OshiftContext
+	ingHostIPMap := map[string]string{host: ingIPAddr}
+
+	t.Cleanup(func() {
+		k8sDeleteIngress(t, clusterClients[K8s], ingName, ns)
+		for _, route := range routeName {
+			oshiftDeleteRoute(t, clusterClients[Oshift], route, ns)
+		}
+		DeleteTestGDP(t, newGDP.Namespace, newGDP.Name)
+	})
+
+	g := gomega.NewGomegaWithT(t)
+
+	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
+		ingHostIPMap, ingPaths, TlsTrue)
+	var routeObj []*routev1.Route
+	for idx, path := range routePaths {
+		name := routePrefix + strconv.Itoa(idx)
+		routeObj = append(routeObj, oshiftAddRoute(t, clusterClients[Oshift], name, ns, ingestion_test.TestSvc,
+			routeCluster, host, routeIPAddr, path, TlsTrue))
+		routeName = append(routeName, name)
+	}
+
+	var expectedMembers []nodes.AviGSK8sObj
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, DefaultPriority))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromMultiPathRoute(t, routeObj, routeCluster, 1, DefaultPriority)...)
+
+	paths := GetUniquePaths(append(ingPaths, routePaths...))
+	hmRefs := BuildTestPathHmNames(host, paths, TlsTrue)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, hmRefs, nil, nil, nil, paths, TlsTrue, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	g.Eventually(func() bool {
+		return verifyGSMembersInRestLayer(t, GetUniqueMembers(expectedMembers), host, utils.ADMIN_NS, hmRefs, nil, nil, nil, paths, TlsTrue)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+func TestHMAddEditHostAndPathIngressAndRoutes(t *testing.T) {
+	newGDP, err := BuildAddAndVerifyAppSelectorTestGDP(t)
+	if err != nil {
+		t.Fatalf("error in building, adding and verifying app selector GDP: %v", err)
+	}
+
+	testPrefix := "hm-cir-"
+	ingName := testPrefix + "ing"
+	routeName := testPrefix + "route"
+	ns := "default"
+	host := testPrefix + ingestion_test.TestDomain1
+	ingIPAddr := "1.1.1.1"
+	routeIPAddr := "2.2.2.2"
+	ingCluster := K8sContext
+	routeCluster := OshiftContext
+	ingHostIPMap := map[string]string{host: ingIPAddr}
+	path := []string{"/"}
+
+	t.Cleanup(func() {
+		k8sDeleteIngress(t, clusterClients[K8s], ingName, ns)
+		oshiftDeleteRoute(t, clusterClients[Oshift], routeName, ns)
+		DeleteTestGDP(t, newGDP.Namespace, newGDP.Name)
+	})
+
+	g := gomega.NewGomegaWithT(t)
+
+	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
+		ingHostIPMap, nil, TlsTrue)
+	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
+		routeCluster, host, routeIPAddr, path[0], TlsTrue)
+
+	var expectedMembers []nodes.AviGSK8sObj
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, DefaultPriority))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, DefaultPriority))
+
+	hmRefs := BuildTestPathHmNames(host, path, TlsTrue)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, hmRefs, nil, nil, nil, path, TlsTrue, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	g.Eventually(func() bool {
+		return verifyGSMembersInRestLayer(t, expectedMembers, host, utils.ADMIN_NS, hmRefs, nil, nil, nil, path, TlsTrue)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	newPath := []string{"/updatedPath"}
+	newHost := "updated-" + host
+	updatedIngHostIPMap := map[string]string{newHost: ingIPAddr}
+
+	newIngObj := k8sUpdateIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, updatedIngHostIPMap, newPath)
+	newRoute := oshiftUpdateRoute(t, clusterClients[K8s], routeName, ns, ingestion_test.TestSvc, newHost, routeIPAddr, newPath[0])
+
+	expectedMembers = nil
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, newIngObj, ingCluster, 1, DefaultPriority))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, newRoute, routeCluster, 1, DefaultPriority))
+
+	hmRefs = BuildTestPathHmNames(newHost, newPath, TlsTrue)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, newHost, utils.ADMIN_NS, hmRefs, nil, nil, nil, newPath, TlsTrue, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	g.Eventually(func() bool {
+		return verifyGSMembersInRestLayer(t, expectedMembers, newHost, utils.ADMIN_NS, hmRefs, nil, nil, nil, newPath, TlsTrue)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+func TestHMAddLBServices(t *testing.T) {
+	newGDP, err := BuildAddAndVerifyAppSelectorTestGDP(t)
+	if err != nil {
+		t.Fatalf("error in building, adding and verifying app selector GDP: %v", err)
+	}
+
+	testPrefix := "hm-cir-"
+	svcName := testPrefix + "svc"
+	ns := "default"
+	host := svcName + "." + ns + "." + ingestion_test.TestDomain1
+	svcIPAddr := "3.3.3.3"
+	svcHostIPMap := map[string]string{host: svcIPAddr}
+	k8sCluster := K8sContext
+	var port int32 = 8080
+
+	t.Cleanup(func() {
+		k8sDeleteService(t, clusterClients[K8s], svcName, ns)
+		DeleteTestGDP(t, newGDP.Namespace, newGDP.Name)
+	})
+
+	g := gomega.NewGomegaWithT(t)
+
+	svcK8sObj := k8sAddLBService(t, clusterClients[K8s], svcName, ns, svcHostIPMap, port)
+
+	var expectedMembers []nodes.AviGSK8sObj
+	expectedMembers = append(expectedMembers, getTestGSMemberFromSvc(t, svcK8sObj, k8sCluster, 1, DefaultPriority))
+
+	hmRefs := []string{BuildTestNonPathHmNames(host)}
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, hmRefs, nil, nil, nil, nil, false, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	g.Eventually(func() bool {
+		return verifyGSMembersInRestLayer(t, expectedMembers, host, utils.ADMIN_NS, hmRefs, nil, nil, nil, nil, false)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+func TestHMUpdateLBServices(t *testing.T) {
+	newGDP, err := BuildAddAndVerifyAppSelectorTestGDP(t)
+	if err != nil {
+		t.Fatalf("error in building, adding and verifying app selector GDP: %v", err)
+	}
+
+	testPrefix := "hm-cir-"
+	svcName := testPrefix + "svc"
+	ns := "default"
+	host := svcName + "." + ns + "." + ingestion_test.TestDomain1
+	svcIPAddr := "3.3.3.3"
+	svcHostIPMap := map[string]string{host: svcIPAddr}
+	k8sCluster := K8sContext
+	var port int32 = 8080
+
+	t.Cleanup(func() {
+		k8sDeleteService(t, clusterClients[K8s], svcName, ns)
+		DeleteTestGDP(t, newGDP.Namespace, newGDP.Name)
+	})
+
+	g := gomega.NewGomegaWithT(t)
+
+	svcK8sObj := k8sAddLBService(t, clusterClients[K8s], svcName, ns, svcHostIPMap, port)
+
+	var expectedMembers []nodes.AviGSK8sObj
+	expectedMembers = append(expectedMembers, getTestGSMemberFromSvc(t, svcK8sObj, k8sCluster, 1, DefaultPriority))
+
+	hmRefs := []string{BuildTestNonPathHmNames(host)}
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, hmRefs, nil, nil, nil, nil, false, &port)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	g.Eventually(func() bool {
+		return verifyGSMembersInRestLayer(t, expectedMembers, host, utils.ADMIN_NS, hmRefs, nil, nil, nil, nil, false)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	port = 9090
+	updatedSvcObj := k8sUpdateLBServicePort(t, clusterClients[K8s], svcName, ns, port)
+
+	expectedMembers = nil
+	expectedMembers = append(expectedMembers, getTestGSMemberFromSvc(t, updatedSvcObj, k8sCluster, 1, DefaultPriority))
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, hmRefs, nil, nil, nil, nil, false, &port)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	g.Eventually(func() bool {
+		return verifyGSMembersInRestLayer(t, expectedMembers, host, utils.ADMIN_NS, hmRefs, nil, nil, nil, nil, false)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}

--- a/gslb/test/integration/third_party_vips/ingress_test.go
+++ b/gslb/test/integration/third_party_vips/ingress_test.go
@@ -175,6 +175,7 @@ func TestDefaultIngressAndRoutes(t *testing.T) {
 	ingCluster := "k8s"
 	routeCluster := "oshift"
 	ingHostIPMap := map[string]string{host: ingIPAddr}
+	path := []string{"/"}
 
 	t.Cleanup(func() {
 		k8sDeleteIngress(t, clusterClients[K8s], ingName, ns)
@@ -184,23 +185,24 @@ func TestDefaultIngressAndRoutes(t *testing.T) {
 	initMiddlewares(t)
 
 	g := gomega.NewGomegaWithT(t)
+	tls := false
 
 	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
-		ingHostIPMap, false)
+		ingHostIPMap, path, tls)
 	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
-		routeCluster, host, routeIPAddr, false)
+		routeCluster, host, routeIPAddr, path[0], tls)
 
 	var expectedMembers []nodes.AviGSK8sObj
 	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
 	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
 
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil, path, tls, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
-	hmNames := BuildTestHmNames(host, []string{"/"}, false)
+	hmNames := BuildTestHmNames(host, path, false)
 	g.Eventually(func() bool {
-		return verifyGSMembersInRestLayer(t, expectedMembers, host, utils.ADMIN_NS, hmNames, nil, nil, nil)
+		return verifyGSMembersInRestLayer(t, expectedMembers, host, utils.ADMIN_NS, hmNames, nil, nil, nil, path, tls)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }
 
@@ -212,7 +214,7 @@ func TestEmptyStatusDefaultIngressAndRoutes(t *testing.T) {
 		t.Fatalf("error in building, adding and verifying app selector GDP: %v", err)
 	}
 
-	testPrefix := "tdrs-"
+	testPrefix := "tdr-"
 	ingName := testPrefix + "def-ing"
 	routeName := testPrefix + "def-route"
 	ns := "default"
@@ -222,6 +224,7 @@ func TestEmptyStatusDefaultIngressAndRoutes(t *testing.T) {
 	ingCluster := "k8s"
 	routeCluster := "oshift"
 	ingHostIPMap := map[string]string{host: ingIPAddr}
+	path := []string{"/"}
 
 	t.Cleanup(func() {
 		k8sDeleteIngress(t, clusterClients[K8s], ingName, ns)
@@ -231,18 +234,19 @@ func TestEmptyStatusDefaultIngressAndRoutes(t *testing.T) {
 
 	initMiddlewares(t)
 	g := gomega.NewGomegaWithT(t)
+	tls := false
 
 	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
-		ingHostIPMap, false)
+		ingHostIPMap, path, tls)
 	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
-		routeCluster, host, routeIPAddr, false)
+		routeCluster, host, routeIPAddr, path[0], tls)
 
 	var expectedMembers []nodes.AviGSK8sObj
 	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
 	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
 
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil, path, tls, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 	// update the ingress object with an empty status field
@@ -252,11 +256,11 @@ func TestEmptyStatusDefaultIngressAndRoutes(t *testing.T) {
 	expectedMembers = []nodes.AviGSK8sObj{getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10)}
 	t.Logf("verifying the GS to have only 1 member as route")
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil, path, tls, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
-	hmNames := BuildTestHmNames(host, []string{"/"}, false)
+	hmNames := BuildTestHmNames(host, path, false)
 	g.Eventually(func() bool {
-		return verifyGSMembersInRestLayer(t, expectedMembers, host, utils.ADMIN_NS, hmNames, nil, nil, nil)
+		return verifyGSMembersInRestLayer(t, expectedMembers, host, utils.ADMIN_NS, hmNames, nil, nil, nil, path, tls)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }

--- a/gslb/test/integration/third_party_vips/ingress_test.go
+++ b/gslb/test/integration/third_party_vips/ingress_test.go
@@ -214,7 +214,7 @@ func TestEmptyStatusDefaultIngressAndRoutes(t *testing.T) {
 		t.Fatalf("error in building, adding and verifying app selector GDP: %v", err)
 	}
 
-	testPrefix := "tdr-"
+	testPrefix := "tdrns-"
 	ingName := testPrefix + "def-ing"
 	routeName := testPrefix + "def-route"
 	ns := "default"

--- a/gslb/test/integration/third_party_vips/ingress_test.go
+++ b/gslb/test/integration/third_party_vips/ingress_test.go
@@ -15,6 +15,8 @@
 package third_party_vips
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -137,6 +139,12 @@ func initMiddlewares(t *testing.T) {
 	})
 }
 
+func EncodeHMName(name string) string {
+	gsNameHash := sha1.Sum([]byte(name))
+	encodedHMName := hex.EncodeToString(gsNameHash[:])
+	return encodedHMName
+}
+
 func BuildTestHmNames(hostname string, paths []string, tls bool) []string {
 	httpType := "http"
 	if tls {
@@ -144,7 +152,7 @@ func BuildTestHmNames(hostname string, paths []string, tls bool) []string {
 	}
 	hmNames := []string{}
 	for _, p := range paths {
-		hmName := "amko--" + httpType + "--" + hostname + "--" + p
+		hmName := "amko--" + EncodeHMName(httpType+"--"+hostname+"--"+p)
 		hmNames = append(hmNames, hmName)
 	}
 	return hmNames

--- a/gslb/test/integration/third_party_vips/int_lib.go
+++ b/gslb/test/integration/third_party_vips/int_lib.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onsi/gomega"
 	routev1 "github.com/openshift/api/route/v1"
 	oshiftclient "github.com/openshift/client-go/route/clientset/versioned"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/cache"
 	avicache "github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/cache"
 	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/gslbutils"
 	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/k8sobjects"
@@ -723,7 +724,7 @@ func verifyGSMembersInRestLayer(t *testing.T, expectedMembers []nodes.AviGSK8sOb
 	}
 
 	sort.Strings(hmRefs)
-	fetchedHmNames := gs.HealthMonitorNames
+	fetchedHmNames := cache.GetHmNameList(gs.HealthMonitor)
 	sort.Strings(fetchedHmNames)
 	if len(hmRefs) != len(fetchedHmNames) {
 		t.Logf("length of hm names don't match, expected: %v, got: %v", hmRefs, fetchedHmNames)

--- a/gslb/test/integration/third_party_vips/int_lib.go
+++ b/gslb/test/integration/third_party_vips/int_lib.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -43,6 +44,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -59,12 +61,17 @@ const (
 	// AMKO CRD directory
 	AmkoCRDs = "../../../../helm/amko/crds"
 
-	AviSystemNS    = "avi-system"
-	AviSecret      = "avi-secret"
-	GslbConfigName = "test-gc"
-	GDPName        = "test-gdp"
-	K8sContext     = "k8s"
-	OshiftContext  = "oshift"
+	AviSystemNS     = "avi-system"
+	AviSecret       = "avi-secret"
+	GslbConfigName  = "test-gc"
+	GDPName         = "test-gdp"
+	K8sContext      = "k8s"
+	OshiftContext   = "oshift"
+	Hostname        = "hostname"
+	Path            = "path"
+	TlsTrue         = true
+	TlsFalse        = false
+	DefaultPriority = 10
 )
 
 var (
@@ -79,20 +86,79 @@ var (
 	KubeBuilderAssetsVal string
 	routeCRD             apiextensionv1beta1.CustomResourceDefinition
 	hrCRD                apiextensionv1beta1.CustomResourceDefinition
+	defaultPath          = []string{"/"}
 )
 
 var appLabel map[string]string = map[string]string{"key": "value"}
 
-func BuildIngressObj(name, ns, svc, cname string, hostIPs map[string]string, withStatus bool, secretName string) *networkingv1beta1.Ingress {
+func BuildLBServiceObj(t *testing.T, name, ns string, hostIPs map[string]string, port int32) *corev1.Service {
+	svcObj := &corev1.Service{}
+	svcObj.Namespace = ns
+	svcObj.Name = name
+
+	svcObj.Spec.Type = "LoadBalancer"
+	ports := corev1.ServicePort{
+		Protocol: "TCP",
+		Port:     port,
+		TargetPort: intstr.IntOrString{
+			Type:   0,
+			IntVal: port,
+		},
+	}
+	svcObj.Spec.Ports = []corev1.ServicePort{ports}
+	svcObj.Spec.Selector = map[string]string{
+		"app": "lb-app",
+	}
+
+	for ingHost, ingIP := range hostIPs {
+		svcObj.Status.LoadBalancer.Ingress = append(svcObj.Status.LoadBalancer.Ingress,
+			corev1.LoadBalancerIngress{
+				IP:       ingIP,
+				Hostname: ingHost,
+			})
+
+	}
+	labelMap := make(map[string]string)
+	labelMap["key"] = "value"
+	svcObj.Labels = labelMap
+	return svcObj
+}
+
+func BuildIngressObj(name, ns, svc, cname string, hostIPs map[string]string, paths []string, withStatus bool, secretName string) *networkingv1beta1.Ingress {
 	ingObj := &networkingv1beta1.Ingress{}
 	ingObj.Namespace = ns
 	ingObj.Name = name
+
+	if paths == nil {
+		paths = []string{"/"}
+	}
+	var ingPaths []networkingv1beta1.HTTPIngressPath
+	var pathType networkingv1beta1.PathType = "ImplementationSpecific"
+	for _, path := range paths {
+		ingPath := networkingv1beta1.HTTPIngressPath{
+			Path:     path,
+			PathType: &pathType,
+			Backend: networkingv1beta1.IngressBackend{
+				ServiceName: svc,
+				ServicePort: intstr.IntOrString{
+					Type:   0,
+					IntVal: 8080,
+				},
+			},
+		}
+		ingPaths = append(ingPaths, ingPath)
+	}
 
 	var hosts []string
 	for ingHost, ingIP := range hostIPs {
 		hosts = append(hosts, ingHost)
 		ingObj.Spec.Rules = append(ingObj.Spec.Rules, networkingv1beta1.IngressRule{
 			Host: ingHost,
+			IngressRuleValue: networkingv1beta1.IngressRuleValue{
+				HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+					Paths: ingPaths,
+				},
+			},
 		})
 		if !withStatus {
 			continue
@@ -118,7 +184,10 @@ func BuildIngressObj(name, ns, svc, cname string, hostIPs map[string]string, wit
 	return ingObj
 }
 
-func BuildRouteObj(name, ns, svc, cname, host, ip string, withStatus bool) *routev1.Route {
+func BuildRouteObj(name, ns, svc, cname, host, ip, path string, withStatus bool) *routev1.Route {
+	if path == "" {
+		path = "/"
+	}
 	routeObj := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
@@ -126,6 +195,7 @@ func BuildRouteObj(name, ns, svc, cname, host, ip string, withStatus bool) *rout
 		},
 		Spec: routev1.RouteSpec{
 			Host: host,
+			Path: path,
 			To: routev1.RouteTargetReference{
 				Kind: "Service",
 				Name: svc,
@@ -219,8 +289,29 @@ func k8sCleanupIngressStatus(t *testing.T, kc *kubernetes.Clientset, cname strin
 	return updatedIng
 }
 
+func k8sAddLBService(t *testing.T, kc *kubernetes.Clientset, name, ns string, hostIPs map[string]string, port int32) *corev1.Service {
+	svcObj := BuildLBServiceObj(t, name, ns, hostIPs, port)
+	hostname := name + "." + ns + "." + ingestion_test.TestDomain1
+	svcObj.Annotations = getAnnotations([]string{hostname})
+
+	svc, err := kc.CoreV1().Services(ns).Create(context.TODO(), svcObj, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create service : %v", err)
+	}
+
+	patchPayload, _ := json.Marshal(map[string]interface{}{
+		"status": svcObj.Status,
+	})
+
+	svc, err = kc.CoreV1().Services(ns).Patch(context.TODO(), name, types.MergePatchType, patchPayload, metav1.PatchOptions{}, "status")
+	if err != nil {
+		t.Fatalf("error in patching service: %v", err)
+	}
+	return svc
+}
+
 func k8sAddIngress(t *testing.T, kc *kubernetes.Clientset, name, ns, svc, cname string,
-	hostIPs map[string]string, tls bool) *networkingv1beta1.Ingress {
+	hostIPs map[string]string, paths []string, tls bool) *networkingv1beta1.Ingress {
 
 	secreName := "test-secret"
 	if tls {
@@ -235,9 +326,9 @@ func k8sAddIngress(t *testing.T, kc *kubernetes.Clientset, name, ns, svc, cname 
 	}
 	var ingObj *networkingv1beta1.Ingress
 	if tls {
-		ingObj = BuildIngressObj(name, ns, svc, cname, hostIPs, true, secreName)
+		ingObj = BuildIngressObj(name, ns, svc, cname, hostIPs, paths, true, secreName)
 	} else {
-		ingObj = BuildIngressObj(name, ns, svc, cname, hostIPs, true, "")
+		ingObj = BuildIngressObj(name, ns, svc, cname, hostIPs, paths, true, "")
 	}
 	t.Logf("built an ingress object with name: %s, ns: %s, cname: %s", ns, name, cname)
 	var hostnames []string
@@ -262,8 +353,8 @@ func k8sAddIngress(t *testing.T, kc *kubernetes.Clientset, name, ns, svc, cname 
 }
 
 func oshiftAddRoute(t *testing.T, kc *kubernetes.Clientset, name, ns, svc, cname, host,
-	ip string, tls bool) *routev1.Route {
-	routeObj := BuildRouteObj(name, ns, svc, cname, host, ip, true)
+	ip, path string, tls bool) *routev1.Route {
+	routeObj := BuildRouteObj(name, ns, svc, cname, host, ip, path, true)
 	if tls {
 		routeObj.Spec.TLS = &routev1.TLSConfig{
 			Termination:   routev1.TLSTerminationEdge,
@@ -287,7 +378,7 @@ func oshiftAddRoute(t *testing.T, kc *kubernetes.Clientset, name, ns, svc, cname
 func k8sDeleteIngress(t *testing.T, kc *kubernetes.Clientset, name string, ns string) {
 	err := kc.NetworkingV1beta1().Ingresses(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
 	if err != nil {
-		t.Fatalf("error in creating ingress: %v", err)
+		t.Fatalf("error in deleting ingress: %v", err)
 	}
 }
 
@@ -296,6 +387,107 @@ func oshiftDeleteRoute(t *testing.T, kc *kubernetes.Clientset, name string, ns s
 	if err != nil {
 		t.Fatalf("Couldn't delete route obj: %v, err: %v", name, err)
 	}
+}
+
+func k8sDeleteService(t *testing.T, kc *kubernetes.Clientset, name string, ns string) {
+	err := kc.CoreV1().Services(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("error in deleting service: %v", err)
+	}
+}
+
+func k8sUpdateIngress(t *testing.T, kc *kubernetes.Clientset, name, ns, svc string, hostIPs map[string]string, paths []string) *networkingv1beta1.Ingress {
+	ingress, err := kc.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error in getting ingress: %v", err)
+	}
+	var ingPaths []networkingv1beta1.HTTPIngressPath
+	var pathType networkingv1beta1.PathType = "ImplementationSpecific"
+	ingress.Spec.Rules = []networkingv1beta1.IngressRule{}
+	ingress.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{}
+	for _, path := range paths {
+		ingPath := networkingv1beta1.HTTPIngressPath{
+			Path:     path,
+			PathType: &pathType,
+			Backend: networkingv1beta1.IngressBackend{
+				ServiceName: svc,
+				ServicePort: intstr.IntOrString{
+					Type:   0,
+					IntVal: 8080,
+				},
+			},
+		}
+		ingPaths = append(ingPaths, ingPath)
+	}
+
+	var hosts []string
+	for ingHost, ingIP := range hostIPs {
+		hosts = append(hosts, ingHost)
+		ingress.Spec.Rules = append(ingress.Spec.Rules, networkingv1beta1.IngressRule{
+			Host: ingHost,
+			IngressRuleValue: networkingv1beta1.IngressRuleValue{
+				HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+					Paths: ingPaths,
+				},
+			},
+		})
+		ingress.Status.LoadBalancer.Ingress = append(ingress.Status.LoadBalancer.Ingress, corev1.LoadBalancerIngress{
+			IP:       ingIP,
+			Hostname: ingHost,
+		})
+	}
+	var hostnames []string
+	for _, r := range ingress.Spec.Rules {
+		hostnames = append(hostnames, r.Host)
+	}
+	ingress.Annotations = getAnnotations(hostnames)
+	if ingress.Spec.TLS != nil && len(ingress.Spec.TLS) > 0 {
+		ingress.Spec.TLS[0].Hosts = hostnames
+	}
+	_, err = kc.NetworkingV1beta1().Ingresses(ns).Update(context.TODO(), ingress, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("error in updating ingress: %v", err)
+	}
+	patchPayload, _ := json.Marshal(map[string]interface{}{
+		"status": ingress.Status,
+	})
+	_, err = kc.NetworkingV1beta1().Ingresses(ns).Patch(context.TODO(), name, types.MergePatchType, patchPayload, metav1.PatchOptions{}, "status")
+	if err != nil {
+		t.Fatalf("error in patching ingress: %v", err)
+	}
+	return ingress
+}
+
+func oshiftUpdateRoute(t *testing.T, kc *kubernetes.Clientset, name, ns, svc, host,
+	ip, path string) *routev1.Route {
+	route, err := oshiftClient.RouteV1().Routes(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error in getting route: %v", err)
+	}
+	route.Spec.Host = host
+	route.Spec.Path = path
+
+	route.Status.Ingress[0].Host = host
+	route.Annotations = getAnnotations([]string{host})
+	_, err = oshiftClient.RouteV1().Routes(ns).Update(context.TODO(), route, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("error in updating ingress: %v", err)
+	}
+	return route
+}
+
+func k8sUpdateLBServicePort(t *testing.T, kc *kubernetes.Clientset, name, ns string, port int32) *corev1.Service {
+	svc, err := kc.CoreV1().Services(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error getting service : %v", err)
+	}
+	svc.Spec.Ports[0].Port = port
+
+	_, err = kc.CoreV1().Services(ns).Update(context.TODO(), svc, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("error updating service : %v", err)
+	}
+	return svc
 }
 
 func BuildAddAndVerifyAppSelectorTestGDP(t *testing.T) (*gdpalphav2.GlobalDeploymentPolicy, error) {
@@ -442,8 +634,50 @@ func GetTestGSGraphFromName(t *testing.T, gsName string) *nodes.AviGSObjectGraph
 	return gsGraph.GetCopy()
 }
 
-func verifyGSMembers(t *testing.T, expectedMembers []nodes.AviGSK8sObj, name, tenant string,
-	hmRefs []string, sitePersistenceRef *string, ttl *int, pa *gslbalphav1.PoolAlgorithmSettings) bool {
+func BuildTestPathHmNames(hostname string, paths []string, tls bool) []string {
+	httpType := "http"
+	if tls {
+		httpType = "https"
+	}
+	hmNames := []string{}
+	for _, p := range paths {
+		hmName := "amko--" + gslbutils.EncodeHMName(httpType+"--"+hostname+"--"+p)
+		hmNames = append(hmNames, hmName)
+	}
+	return hmNames
+}
+
+func BuildTestNonPathHmNames(hostname string) string {
+	return "amko--" + gslbutils.EncodeHMName(hostname)
+}
+
+func BuildExpectedPathHmNameDescription(host string, path string, tls bool) (string, string) {
+	protocol := "http"
+	if tls {
+		protocol = "https"
+	}
+	hmName := "amko--" + gslbutils.EncodeHMName(protocol+"--"+host+"--"+path)
+	hmDesc := nodes.CreatedByAMKO + ", gsname: " + host + ", path: " + path + ", protocol: " + protocol
+	return hmName, hmDesc
+
+}
+
+func BuildExpectedNonPathHmDescription(host string) string {
+	return nodes.CreatedByAMKO + ", gsname: " + host
+}
+
+func compareHmRefs(t *testing.T, expectedHmRefs, fetchedHmRefs []string) bool {
+	for idx, h := range expectedHmRefs {
+		if h != fetchedHmRefs[idx] {
+			t.Logf("hm ref didn't match, expected list: %v, fetched list: %v", expectedHmRefs, fetchedHmRefs)
+			return false
+		}
+	}
+	return true
+}
+
+func verifyGSMembers(t *testing.T, expectedMembers []nodes.AviGSK8sObj, name string, tenant string,
+	hmRefs []string, sitePersistenceRef *string, ttl *int, pa *gslbalphav1.PoolAlgorithmSettings, paths []string, tls bool, port *int32) bool {
 
 	gs := GetTestGSGraphFromName(t, name)
 	if gs == nil {
@@ -456,23 +690,57 @@ func verifyGSMembers(t *testing.T, expectedMembers []nodes.AviGSK8sObj, name, te
 		return false
 	}
 
-	sort.Strings(hmRefs)
-	fetchedHmRefs := gs.HmRefs
-	sort.Strings(fetchedHmRefs)
-	if len(hmRefs) != len(fetchedHmRefs) {
-		t.Logf("length of hm refs don't match, expected: %v, got: %v", hmRefs, fetchedHmRefs)
-		return false
-	}
+	if hmRefs != nil && len(hmRefs) != 0 {
+		sort.Strings(hmRefs)
+		if !strings.HasPrefix(hmRefs[0], "amko--") {
+			// hm not created by amko
+			fetchedHmRefs := gs.HmRefs
+			sort.Strings(fetchedHmRefs)
+			if len(hmRefs) != len(fetchedHmRefs) {
+				t.Logf("length of hm refs don't match, expected: %v, got: %v", hmRefs, fetchedHmRefs)
+				return false
+			}
 
-	if len(hmRefs) != 0 {
-		for idx, h := range hmRefs {
-			if h != fetchedHmRefs[idx] {
-				t.Logf("hm ref didn't match, expected list: %v, fetched list: %v", hmRefs, fetchedHmRefs)
+			if len(hmRefs) != 0 && !compareHmRefs(t, hmRefs, fetchedHmRefs) {
+				return false
+			}
+		} else if paths != nil {
+			// path based HMs
+			fetchedHmRefs := nodes.GetHmNameListFromPathNames(gs.Hm.PathNames)
+			sort.Strings(fetchedHmRefs)
+			if len(hmRefs) != len(fetchedHmRefs) {
+				t.Logf("length of hm refs don't match, expected: %v, got: %v", hmRefs, fetchedHmRefs)
+				return false
+			}
+			if !compareHmRefs(t, hmRefs, fetchedHmRefs) {
+				return false
+			}
+			for _, path := range paths {
+				expectedHmName, expectedHmDesc := BuildExpectedPathHmNameDescription(name, path, tls)
+				for _, p := range gs.Hm.PathNames {
+					if p.Path == path && (p.HmName != expectedHmName || p.Description != expectedHmDesc) {
+						t.Logf("hm name, description didn't match, expected : %s,%s , fetched list: %s,%s", expectedHmName, expectedHmDesc, p.HmName, p.Description)
+						return false
+					}
+				}
+			}
+		} else {
+			// non path based HM
+			if gs.Hm.Name != hmRefs[0] {
+				t.Logf("hm names do not match, expected : %s, got : %s", hmRefs[0], gs.Hm.Name)
+				return false
+			}
+			if port != nil && *port != gs.Hm.Port {
+				t.Logf("hm port do not match, expected : %d, got : %d", *port, gs.Hm.Port)
+				return false
+			}
+			expectedHmDesc := BuildExpectedNonPathHmDescription(name)
+			if gs.Hm.Description != expectedHmDesc {
+				t.Logf("hm description do not match, expected : %s, got : %s", expectedHmDesc, gs.Hm.Description)
 				return false
 			}
 		}
 	}
-
 	if sitePersistenceRef != nil {
 		if gs.SitePersistenceRef == nil {
 			t.Logf("Site persistence ref should not be nil, expected value: %s", *sitePersistenceRef)
@@ -601,6 +869,41 @@ func getTestGSMemberFromRoute(t *testing.T, routeObj *routev1.Route, cname strin
 		true, false, tls, paths, weight, priority)
 }
 
+func getTestGSMemberFromMultiPathRoute(t *testing.T, routeObjList []*routev1.Route, cname string,
+	weight int32, priority int32) []nodes.AviGSK8sObj {
+	var gsMemberList []nodes.AviGSK8sObj
+
+	for _, routeObj := range routeObjList {
+		vsUUIDs := make(map[string]string)
+		if err := json.Unmarshal([]byte(routeObj.Annotations[k8sobjects.VSAnnotation]), &vsUUIDs); err != nil {
+			t.Fatalf("error in getting annotations from route object %v: %v", routeObj.Annotations, err)
+		}
+		var tls bool
+		if routeObj.Spec.TLS != nil {
+			tls = true
+		}
+		gsMemberList = append(gsMemberList, getTestGSMember(cname, gslbutils.RouteType, routeObj.Name, routeObj.Namespace,
+			routeObj.Status.Ingress[0].Conditions[0].Message, vsUUIDs[routeObj.Spec.Host],
+			routeObj.Annotations[k8sobjects.ControllerAnnotation],
+			true, false, tls, []string{routeObj.Spec.Path}, weight, priority))
+	}
+	return gsMemberList
+}
+
+func getTestGSMemberFromSvc(t *testing.T, svcObj *corev1.Service, cname string,
+	weight int32, priority int32) nodes.AviGSK8sObj {
+	vsUUIDs := make(map[string]string)
+	if err := json.Unmarshal([]byte(svcObj.Annotations[k8sobjects.VSAnnotation]), &vsUUIDs); err != nil {
+		t.Fatalf("error in getting annotations from ingress object %v: %v", svcObj.Annotations, err)
+	}
+	hostName := svcObj.Status.LoadBalancer.Ingress[0].Hostname
+
+	return getTestGSMember(cname, gslbutils.SvcType, svcObj.Name, svcObj.Namespace,
+		svcObj.Status.LoadBalancer.Ingress[0].IP, vsUUIDs[hostName],
+		svcObj.Annotations[k8sobjects.ControllerAnnotation],
+		true, false, false, []string{}, weight, priority)
+}
+
 func getTestGSMember(cname, objType, name, ns, ipAddr, vsUUID, controllerUUID string,
 	syncVIPOnly, isPassthrough, tls bool, paths []string, weight int32, priority int32) nodes.AviGSK8sObj {
 	return nodes.AviGSK8sObj{
@@ -709,8 +1012,8 @@ func GetTestGSFromRestCache(t *testing.T, gsName string) *avicache.AviGSCache {
 	return gsObj
 }
 
-func verifyGSMembersInRestLayer(t *testing.T, expectedMembers []nodes.AviGSK8sObj, name, tenant string,
-	hmRefs []string, sitePersistenceRef *string, ttl *int, pa *gslbalphav1.PoolAlgorithmSettings) bool {
+func verifyGSMembersInRestLayer(t *testing.T, expectedMembers []nodes.AviGSK8sObj, name string, tenant string,
+	hmRefs []string, sitePersistenceRef *string, ttl *int, pa *gslbalphav1.PoolAlgorithmSettings, paths []string, tls bool) bool {
 
 	gs := GetTestGSFromRestCache(t, name)
 	if gs == nil {
@@ -722,22 +1025,47 @@ func verifyGSMembersInRestLayer(t *testing.T, expectedMembers []nodes.AviGSK8sOb
 		t.Logf("length of members don't match")
 		return false
 	}
-
-	sort.Strings(hmRefs)
-	fetchedHmNames := cache.GetHmNameList(gs.HealthMonitor)
-	sort.Strings(fetchedHmNames)
-	if len(hmRefs) != len(fetchedHmNames) {
-		t.Logf("length of hm names don't match, expected: %v, got: %v", hmRefs, fetchedHmNames)
-		return false
-	}
-
-	if len(hmRefs) != 0 {
-		for idx, h := range hmRefs {
-			if h != fetchedHmNames[idx] {
-				t.Logf("hm ref didn't match, expected list: %v, fetched list: %v", hmRefs, fetchedHmNames)
+	if hmRefs != nil && len(hmRefs) != 0 {
+		sort.Strings(hmRefs)
+		fetchedHmRefs := cache.GetHmNameList(gs.HealthMonitor)
+		sort.Strings(fetchedHmRefs)
+		if len(hmRefs) != len(fetchedHmRefs) {
+			t.Logf("length of hm names don't match, expected: %v, got: %v", hmRefs, fetchedHmRefs)
+			return false
+		}
+		if !compareHmRefs(t, hmRefs, fetchedHmRefs) {
+			return false
+		}
+		if paths != nil {
+			expectedHmDesc := []string{}
+			for _, path := range paths {
+				_, desc := BuildExpectedPathHmNameDescription(name, path, tls)
+				expectedHmDesc = append(expectedHmDesc, desc)
+			}
+			hmDesc := []string{}
+			for _, gsHm := range gs.HealthMonitor {
+				hmDesc = append(hmDesc, gsHm.HealthMonitorDescription)
+			}
+			if len(expectedHmDesc) != len(hmDesc) {
+				t.Logf("length of hm descriptions dont match, expected: %v, got: %v", expectedHmDesc, hmDesc)
 				return false
 			}
+			sort.Strings(expectedHmDesc)
+			sort.Strings(hmDesc)
+			for idx := range hmDesc {
+				if hmDesc[idx] != expectedHmDesc[idx] {
+					t.Logf("hm descriptions dont match, expected: %v, got: %v", expectedHmDesc, hmDesc)
+					return false
+				}
+			}
+		} else {
+			for _, gsHm := range gs.HealthMonitor {
+				if gsHm.HealthMonitorDescription != BuildExpectedNonPathHmDescription(name) {
+					t.Logf("hm descriptions dont match")
+				}
+			}
 		}
+
 	}
 
 	memberProperties := make(map[string]interface{})
@@ -757,4 +1085,35 @@ func verifyGSMembersInRestLayer(t *testing.T, expectedMembers []nodes.AviGSK8sOb
 		}
 	}
 	return true
+}
+
+// Used to get union set of multi paths of ingress/route with the same host
+func GetUniquePaths(paths []string) []string {
+	uniquePathsSet := make(map[string]struct{})
+	for _, path := range paths {
+		uniquePathsSet[path] = struct{}{}
+	}
+	uniquePaths := []string{}
+	for path := range uniquePathsSet {
+		uniquePaths = append(uniquePaths, path)
+	}
+	return uniquePaths
+}
+
+// Can be used to get unqiue members when ingress/route have multi paths
+func GetUniqueMembers(members []nodes.AviGSK8sObj) []nodes.AviGSK8sObj {
+	uniqueMembers := []nodes.AviGSK8sObj{}
+	for _, member := range members {
+		exists := false
+		for _, umem := range uniqueMembers {
+			if member.IPAddr == umem.IPAddr {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			uniqueMembers = append(uniqueMembers, member)
+		}
+	}
+	return uniqueMembers
 }

--- a/gslb/test/integration/third_party_vips/pool_priority_test.go
+++ b/gslb/test/integration/third_party_vips/pool_priority_test.go
@@ -252,7 +252,7 @@ func TestPriorityOneClusterUpdate(t *testing.T) {
 	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
 		ingHostIPMap, defaultPath, TlsFalse)
 	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
-		routeCluster, host, routeIPAddr, defaultPath[0], false)
+		routeCluster, host, routeIPAddr, defaultPath[0], TlsFalse)
 
 	var expectedMembers []nodes.AviGSK8sObj
 	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster,
@@ -319,9 +319,9 @@ func TestMultiplePriorityUpdate(t *testing.T) {
 
 	g := gomega.NewGomegaWithT(t)
 	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
-		ingHostIPMap, false)
+		ingHostIPMap, defaultPath, TlsFalse)
 	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
-		routeCluster, host, routeIPAddr, false)
+		routeCluster, host, routeIPAddr, defaultPath[0], TlsFalse)
 
 	var expectedMembers []nodes.AviGSK8sObj
 	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster,
@@ -330,7 +330,7 @@ func TestMultiplePriorityUpdate(t *testing.T) {
 		int32(oshiftWeight), int32(oshiftPriority)))
 
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil, defaultPath, TlsFalse, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 	updTrafficSplit := BuildTestTrafficSplit(k8sWeight, k8sPriority, oshiftWeight, UpdatedPriorityOshift)
@@ -345,6 +345,6 @@ func TestMultiplePriorityUpdate(t *testing.T) {
 	updatedGSMembers = append(updatedGSMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster,
 		int32(oshiftWeight), int32(UpdatedPriorityOshift)))
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, updatedGSMembers, host, utils.ADMIN_NS, nil, nil, nil, nil)
+		return verifyGSMembers(t, updatedGSMembers, host, utils.ADMIN_NS, nil, nil, nil, nil, defaultPath, TlsFalse, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }

--- a/gslb/test/integration/third_party_vips/pool_priority_test.go
+++ b/gslb/test/integration/third_party_vips/pool_priority_test.go
@@ -84,9 +84,9 @@ func TestPoolPriorityValidity(t *testing.T) {
 
 	g := gomega.NewGomegaWithT(t)
 	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
-		ingHostIPMap, false)
+		ingHostIPMap, defaultPath, TlsFalse)
 	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
-		routeCluster, host, routeIPAddr, false)
+		routeCluster, host, routeIPAddr, defaultPath[0], TlsFalse)
 
 	var expectedMembers []nodes.AviGSK8sObj
 	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster,
@@ -95,7 +95,7 @@ func TestPoolPriorityValidity(t *testing.T) {
 		int32(commonWeight), int32(commonPriority)))
 
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil, defaultPath, TlsFalse, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }
 
@@ -129,9 +129,9 @@ func TestMultiplePriorityValidity(t *testing.T) {
 
 	g := gomega.NewGomegaWithT(t)
 	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
-		ingHostIPMap, false)
+		ingHostIPMap, defaultPath, TlsFalse)
 	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
-		routeCluster, host, routeIPAddr, false)
+		routeCluster, host, routeIPAddr, defaultPath[0], TlsFalse)
 
 	var expectedMembers []nodes.AviGSK8sObj
 	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster,
@@ -140,7 +140,7 @@ func TestMultiplePriorityValidity(t *testing.T) {
 		int32(oshiftWeight), int32(oshiftPriority)))
 
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil, defaultPath, TlsFalse, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }
 
@@ -187,9 +187,9 @@ func TestPriorityOnOneCluster(t *testing.T) {
 
 	g := gomega.NewGomegaWithT(t)
 	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
-		ingHostIPMap, false)
+		ingHostIPMap, defaultPath, TlsFalse)
 	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
-		routeCluster, host, routeIPAddr, false)
+		routeCluster, host, routeIPAddr, defaultPath[0], TlsFalse)
 
 	var expectedMembers []nodes.AviGSK8sObj
 	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster,
@@ -198,7 +198,7 @@ func TestPriorityOnOneCluster(t *testing.T) {
 		int32(oshiftWeight), int32(oshiftPriority)))
 
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil, defaultPath, TlsFalse, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }
 
@@ -250,9 +250,9 @@ func TestPriorityOneClusterUpdate(t *testing.T) {
 
 	g := gomega.NewGomegaWithT(t)
 	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
-		ingHostIPMap, false)
+		ingHostIPMap, defaultPath, TlsFalse)
 	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
-		routeCluster, host, routeIPAddr, false)
+		routeCluster, host, routeIPAddr, defaultPath[0], false)
 
 	var expectedMembers []nodes.AviGSK8sObj
 	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster,
@@ -261,7 +261,7 @@ func TestPriorityOneClusterUpdate(t *testing.T) {
 		int32(oshiftWeight), int32(oshiftPriority)))
 
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil, defaultPath, TlsFalse, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 	updTrafficSplit := []gdpalphav2.TrafficSplitElem{
@@ -282,7 +282,7 @@ func TestPriorityOneClusterUpdate(t *testing.T) {
 	updatedGSMembers = append(updatedGSMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster,
 		int32(oshiftWeight), int32(oshiftPriority)))
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, updatedGSMembers, host, utils.ADMIN_NS, nil, nil, nil, nil)
+		return verifyGSMembers(t, updatedGSMembers, host, utils.ADMIN_NS, nil, nil, nil, nil, defaultPath, TlsFalse, nil)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }
 

--- a/gslb/test/restlayer/rest_test.go
+++ b/gslb/test/restlayer/rest_test.go
@@ -89,24 +89,25 @@ func buildTestGSGraph(clusterList, ipList, objNames []string, host, objType stri
 		}
 		memberObjs = append(memberObjs, memberObj)
 	}
-
+	path := "/"
+	protocol := "https"
 	gsGraph := nodes.AviGSObjectGraph{
 		Name:        host,
 		Tenant:      utils.ADMIN_NS,
 		DomainNames: []string{host},
 		MemberObjs:  memberObjs,
 		Hm: nodes.HealthMonitor{
-			Custom:   true,
-			Protocol: gslbutils.SystemGslbHealthMonitorHTTPS,
-			Port:     443,
-			PathNames: []nodes.HealthMonitorPathDescription{
+			Name:       "",
+			HMProtocol: gslbutils.SystemGslbHealthMonitorHTTPS,
+			Port:       443,
+			Type:       nodes.PathHM,
+			PathHM: []nodes.PathHealthMonitorDetails{
 				{
-					HmName:      "amko--d32527f936da2c6c888e4c53d19e1eda52735f5c",
-					GsName:      "host1.foo.com",
-					Path:        "/",
-					Protocol:    "https",
-					Description: "created by: amko, gsname: host1.foo.com, path: /, protocol: https",
-				}},
+					Name:            "amko--d32527f936da2c6c888e4c53d19e1eda52735f5c",
+					IngressProtocol: protocol,
+					Path:            path,
+				},
+			},
 		},
 	}
 	gsGraph.GetChecksum()

--- a/gslb/test/restlayer/rest_test.go
+++ b/gslb/test/restlayer/rest_test.go
@@ -96,10 +96,17 @@ func buildTestGSGraph(clusterList, ipList, objNames []string, host, objType stri
 		DomainNames: []string{host},
 		MemberObjs:  memberObjs,
 		Hm: nodes.HealthMonitor{
-			Custom:    true,
-			Protocol:  gslbutils.SystemGslbHealthMonitorHTTPS,
-			Port:      443,
-			PathNames: []string{"amko--https--host1.foo.com--/"},
+			Custom:   true,
+			Protocol: gslbutils.SystemGslbHealthMonitorHTTPS,
+			Port:     443,
+			PathNames: []nodes.HealthMonitorPathDescription{
+				{
+					HmName:      "amko--d32527f936da2c6c888e4c53d19e1eda52735f5c",
+					GsName:      "host1.foo.com",
+					Path:        "/",
+					Protocol:    "https",
+					Description: "created by: amko, gsname: host1.foo.com, path: /, protocol: https",
+				}},
 		},
 	}
 	gsGraph.GetChecksum()


### PR DESCRIPTION
HealthMonitor names are encoded to avoid any error with name length limits.
A new structure is introduced to store details for any Path Based HMs.

Each HM has a description with the required details like -
1. For Non Path Based HMs - FQDN/GSName
2. Path Based HMs - FQDN/GSName, Path, Protcol(http/https)

HM Checksums computation now considers HM description instead of HM Name

HM Cache object is modified to store the description of the HMs.

Integration tests added to verify health monitor name and description :
1. Add ingress and route
2. Add ingress and route with multi paths
3. Edit/update ingress and route - path and hostname
4. Add LB service
5. Edit/update LB service - port