### PR TITLE
Pool Priority Support for GSLB Services

### DIFF
--- a/gslb/ingestion/gdp_controller.go
+++ b/gslb/ingestion/gdp_controller.go
@@ -319,6 +319,9 @@ func GDPSanityChecks(gdp *gdpalphav2.GlobalDeploymentPolicy, fullSync bool) erro
 		if tp.Weight < 1 || tp.Weight > 20 {
 			return errors.New("traffic weight " + strconv.Itoa(int(tp.Weight)) + " must be between 1 and 20")
 		}
+		if tp.Priority > 100 {
+			return errors.New("priority " + strconv.Itoa(int(tp.Priority)) + " must be between 1 and 100")
+		}
 	}
 
 	// Health monotor validity

--- a/gslb/nodes/dq_ingestion.go
+++ b/gslb/nodes/dq_ingestion.go
@@ -68,6 +68,22 @@ func GetObjTrafficRatio(ns, cname string) int32 {
 	return val
 }
 
+func GetObjTrafficPriority(ns, cname string) int32 {
+	globalFilter := gslbutils.GetGlobalFilter()
+	if globalFilter == nil {
+		// return default priority
+		gslbutils.Errf("ns: %s, cname: %s, msg: global filter can't be nil at this stage", ns, cname)
+		return 10
+	}
+	val, err := globalFilter.GetTrafficPriority(cname)
+	if err != nil {
+		gslbutils.Warnf("ns: %s, cname: %s, msg: error occured while fetching traffic priority info for this cluster, %s",
+			ns, cname, err.Error())
+		return 10
+	}
+	return val
+}
+
 func getObjFromStore(objType, cname, ns, objName, key, storeType string) interface{} {
 	var cstore *store.ClusterStore
 	switch objType {

--- a/gslb/test/integration/third_party_vips/gslb_hostrule_test.go
+++ b/gslb/test/integration/third_party_vips/gslb_hostrule_test.go
@@ -137,8 +137,8 @@ func TestGDPPropertiesForHealthMonitor(t *testing.T) {
 	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
 
 	var expectedMembers []nodes.AviGSK8sObj
-	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
-	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
 	g := gomega.NewGomegaWithT(t)
 
 	g.Eventually(func() bool {
@@ -185,8 +185,8 @@ func TestGDPPropertiesForPersistenceProfile(t *testing.T) {
 	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
 
 	var expectedMembers []nodes.AviGSK8sObj
-	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
-	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
 	g := gomega.NewGomegaWithT(t)
 
 	g.Eventually(func() bool {
@@ -205,8 +205,8 @@ func TestGDPPropertiesForTTL(t *testing.T) {
 	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
 
 	var expectedMembers []nodes.AviGSK8sObj
-	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
-	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
 	g := gomega.NewGomegaWithT(t)
 
 	g.Eventually(func() bool {
@@ -239,8 +239,8 @@ func TestGDPPropertiesForPoolAlgorithm(t *testing.T) {
 	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
 
 	var expectedMembers []nodes.AviGSK8sObj
-	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
-	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
 	g := gomega.NewGomegaWithT(t)
 
 	g.Eventually(func() bool {
@@ -282,8 +282,8 @@ func TestGDPPropertiesForPoolAlgorithmCombinations(t *testing.T) {
 	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
 	verifyMembers := func(pa gslbalphav1.PoolAlgorithmSettings) {
 		var expectedMembers []nodes.AviGSK8sObj
-		expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
-		expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+		expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+		expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
 		g := gomega.NewGomegaWithT(t)
 
 		g.Eventually(func() bool {
@@ -355,8 +355,8 @@ func TestGSLBHostRuleCreate(t *testing.T) {
 	addTestGDPWithProperties(t, hmRefs, &ttl, &sp, nil)
 	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
 	var expectedMembers []nodes.AviGSK8sObj
-	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
-	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
 	g := gomega.NewGomegaWithT(t)
 
 	g.Eventually(func() bool {
@@ -388,8 +388,8 @@ func TestGSLBHostRuleUpdate(t *testing.T) {
 	addTestGDPWithProperties(t, hmRefs, &ttl, &sp, nil)
 	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
 	var expectedMembers []nodes.AviGSK8sObj
-	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
-	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
 	g := gomega.NewGomegaWithT(t)
 
 	hostName := routeObj.Spec.Host
@@ -442,8 +442,8 @@ func TestGSLBHostRuleDelete(t *testing.T) {
 	addTestGDPWithProperties(t, hmRefs, &ttl, &sp, nil)
 	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
 	var expectedMembers []nodes.AviGSK8sObj
-	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
-	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
 	g := gomega.NewGomegaWithT(t)
 
 	hostName := routeObj.Spec.Host
@@ -476,8 +476,8 @@ func TestGSLBHostRuleCreateInvalidHM(t *testing.T) {
 	addTestGDPWithProperties(t, hmRefs, &ttl, &sp, nil)
 	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
 	var expectedMembers []nodes.AviGSK8sObj
-	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
-	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
 	g := gomega.NewGomegaWithT(t)
 
 	g.Eventually(func() bool {
@@ -506,8 +506,8 @@ func TestGDPPropertiesForInvalidHealthMonitorUpdate(t *testing.T) {
 	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
 
 	var expectedMembers []nodes.AviGSK8sObj
-	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
-	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
 	g := gomega.NewGomegaWithT(t)
 
 	g.Eventually(func() bool {
@@ -556,8 +556,8 @@ func TestGSLBHostRuleAlgorithmCombinations(t *testing.T) {
 	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
 	verifyMembers := func(pa gslbalphav1.PoolAlgorithmSettings) {
 		var expectedMembers []nodes.AviGSK8sObj
-		expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
-		expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+		expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+		expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
 		g := gomega.NewGomegaWithT(t)
 
 		g.Eventually(func() bool {

--- a/gslb/test/integration/third_party_vips/ingress_test.go
+++ b/gslb/test/integration/third_party_vips/ingress_test.go
@@ -183,8 +183,8 @@ func TestDefaultIngressAndRoutes(t *testing.T) {
 		routeCluster, host, routeIPAddr, false)
 
 	var expectedMembers []nodes.AviGSK8sObj
-	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
-	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
 
 	g.Eventually(func() bool {
 		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil)
@@ -230,8 +230,8 @@ func TestEmptyStatusDefaultIngressAndRoutes(t *testing.T) {
 		routeCluster, host, routeIPAddr, false)
 
 	var expectedMembers []nodes.AviGSK8sObj
-	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
-	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
 
 	g.Eventually(func() bool {
 		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil)
@@ -241,7 +241,7 @@ func TestEmptyStatusDefaultIngressAndRoutes(t *testing.T) {
 	newIng := k8sGetIngress(t, clusterClients[K8s], ingObj.Name, ingObj.Namespace, ingCluster)
 	k8sCleanupIngressStatus(t, clusterClients[K8s], ingCluster, newIng)
 
-	expectedMembers = []nodes.AviGSK8sObj{getTestGSMemberFromRoute(t, routeObj, routeCluster, 1)}
+	expectedMembers = []nodes.AviGSK8sObj{getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10)}
 	t.Logf("verifying the GS to have only 1 member as route")
 	g.Eventually(func() bool {
 		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil)

--- a/gslb/test/integration/third_party_vips/pool_priority_test.go
+++ b/gslb/test/integration/third_party_vips/pool_priority_test.go
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package third_party_vips
+
+import (
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/nodes"
+	ingestion_test "github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/test/ingestion"
+	gdpalphav2 "github.com/vmware/global-load-balancing-services-for-kubernetes/internal/apis/amko/v1alpha2"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+)
+
+const (
+	defaultPriority = uint32(10)
+	defaultWeight   = uint32(1)
+)
+
+func CreateTestGDPObjectWithPriority(t *testing.T, trafficSplit []gdpalphav2.TrafficSplitElem) *gdpalphav2.GlobalDeploymentPolicy {
+	newGDP, err := BuildAddAndVerifyPoolPriorityTestGDP(t, trafficSplit)
+	if err != nil {
+		t.Fatalf("error in building, adding and verifying pool priority GDP: %v", err)
+	}
+	t.Cleanup(func() {
+		DeleteTestGDP(t, newGDP.Namespace, newGDP.Name)
+	})
+	return newGDP
+}
+
+func BuildTestTrafficSplit(k8sWeight, k8sPriority, oshiftWeight, oshiftPriority uint32) []gdpalphav2.TrafficSplitElem {
+	return []gdpalphav2.TrafficSplitElem{
+		{
+			Cluster:  K8sContext,
+			Weight:   k8sWeight,
+			Priority: k8sPriority,
+		},
+		{
+			Cluster:  OshiftContext,
+			Weight:   oshiftWeight,
+			Priority: oshiftPriority,
+		},
+	}
+}
+
+func TestPoolPriorityValidity(t *testing.T) {
+	// add a GDP object with pool priority set as 10 for both clusters
+	// add an ingress object
+	// add a route object
+	// verify that the GS graph contains both the members with priorities as 10
+	var commonPriority uint32 = 8
+	var commonWeight uint32 = 5
+	trafficSplit := BuildTestTrafficSplit(commonWeight, commonPriority, commonWeight, commonPriority)
+	CreateTestGDPObjectWithPriority(t, trafficSplit)
+
+	testPrefix := "tppv-"
+	ingName := testPrefix + "def-ing"
+	routeName := testPrefix + "def-route"
+	ns := "default"
+	host := testPrefix + ingestion_test.TestDomain1
+	ingIPAddr := "1.1.1.1"
+	routeIPAddr := "2.2.2.2"
+	ingCluster := "k8s"
+	routeCluster := "oshift"
+	ingHostIPMap := map[string]string{host: ingIPAddr}
+
+	t.Cleanup(func() {
+		k8sDeleteIngress(t, clusterClients[K8s], ingName, ns)
+		oshiftDeleteRoute(t, clusterClients[Oshift], routeName, ns)
+	})
+
+	g := gomega.NewGomegaWithT(t)
+	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
+		ingHostIPMap, false)
+	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
+		routeCluster, host, routeIPAddr, false)
+
+	var expectedMembers []nodes.AviGSK8sObj
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster,
+		int32(commonWeight), int32(commonPriority)))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster,
+		int32(commonWeight), int32(commonPriority)))
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+func TestMultiplePriorityValidity(t *testing.T) {
+	// add a GDP object with both clusters having different priorities
+	// add an ingress object and a route object
+	// verify that the gs graph contains both members with different priorities
+	var k8sPriority uint32 = 12
+	var oshiftPriority uint32 = 15
+	var k8sWeight uint32 = 5
+	var oshiftWeight uint32 = 5
+
+	trafficSplit := BuildTestTrafficSplit(k8sWeight, k8sPriority, oshiftWeight, oshiftPriority)
+	CreateTestGDPObjectWithPriority(t, trafficSplit)
+
+	testPrefix := "tmpv-"
+	ingName := testPrefix + "def-ing"
+	routeName := testPrefix + "def-route"
+	ns := "default"
+	host := testPrefix + ingestion_test.TestDomain1
+	ingIPAddr := "1.1.1.1"
+	routeIPAddr := "2.2.2.2"
+	ingCluster := "k8s"
+	routeCluster := "oshift"
+	ingHostIPMap := map[string]string{host: ingIPAddr}
+
+	t.Cleanup(func() {
+		k8sDeleteIngress(t, clusterClients[K8s], ingName, ns)
+		oshiftDeleteRoute(t, clusterClients[Oshift], routeName, ns)
+	})
+
+	g := gomega.NewGomegaWithT(t)
+	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
+		ingHostIPMap, false)
+	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
+		routeCluster, host, routeIPAddr, false)
+
+	var expectedMembers []nodes.AviGSK8sObj
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster,
+		int32(k8sWeight), int32(k8sPriority)))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster,
+		int32(oshiftWeight), int32(oshiftPriority)))
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+func TestPriorityOnOneCluster(t *testing.T) {
+	// add a GDP object with only one cluster in the trafficSplit field.
+	// traffic properties for k8s cluster will be provided, oshift cluster's properties
+	// won't be provided, AMKO should assign the defaults
+	// add an ingress object and a route object
+	// verify the properties for both the clusters including the default values for oshift
+	// cluster
+	var k8sPriority uint32 = 12
+	// default priority of 10 for oshift cluster, as we won't be specifying any priority for
+	// the oshift cluster in the GDP object
+	var oshiftPriority uint32 = defaultPriority
+	var k8sWeight uint32 = 5
+	// default weight of 1 for oshift cluster, as we won't be specifying any weight for the
+	// oshift cluster in the GDP object
+	var oshiftWeight uint32 = defaultWeight
+
+	trafficSplit := []gdpalphav2.TrafficSplitElem{
+		{
+			Cluster:  K8sContext,
+			Weight:   k8sWeight,
+			Priority: k8sPriority,
+		},
+	}
+	CreateTestGDPObjectWithPriority(t, trafficSplit)
+
+	testPrefix := "tmpv-"
+	ingName := testPrefix + "def-ing"
+	routeName := testPrefix + "def-route"
+	ns := "default"
+	host := testPrefix + ingestion_test.TestDomain1
+	ingIPAddr := "1.1.1.1"
+	routeIPAddr := "2.2.2.2"
+	ingCluster := "k8s"
+	routeCluster := "oshift"
+	ingHostIPMap := map[string]string{host: ingIPAddr}
+
+	t.Cleanup(func() {
+		k8sDeleteIngress(t, clusterClients[K8s], ingName, ns)
+		oshiftDeleteRoute(t, clusterClients[Oshift], routeName, ns)
+	})
+
+	g := gomega.NewGomegaWithT(t)
+	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
+		ingHostIPMap, false)
+	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
+		routeCluster, host, routeIPAddr, false)
+
+	var expectedMembers []nodes.AviGSK8sObj
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster,
+		int32(k8sWeight), int32(k8sPriority)))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster,
+		int32(oshiftWeight), int32(oshiftPriority)))
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+func TestPriorityOneClusterUpdate(t *testing.T) {
+	// - add a GDP object with only one cluster in the trafficSplit field.
+	// - traffic properties for k8s cluster will be provided, oshift cluster's properties
+	//   won't be provided, AMKO should assign the defaults
+	// - add an ingress object and a route object
+	// - verify the properties for both the clusters including the default values for oshift
+	//   cluster
+	// - update the GDP object with a different priority for the k8s cluster
+	// - verify the members again
+	var k8sPriority uint32 = 12
+	// default priority of 10 for oshift cluster, as we won't be specifying any priority for
+	// the oshift cluster in the GDP object
+	var oshiftPriority uint32 = defaultPriority
+	var k8sWeight uint32 = 5
+	// default weight of 1 for oshift cluster, as we won't be specifying any weight for the
+	// oshift cluster in the GDP object
+	var oshiftWeight uint32 = defaultWeight
+
+	// updated priority
+	var k8sPriorityUpdated uint32 = 20
+
+	trafficSplit := []gdpalphav2.TrafficSplitElem{
+		{
+			Cluster:  K8sContext,
+			Weight:   k8sWeight,
+			Priority: k8sPriority,
+		},
+	}
+	gdpObj := CreateTestGDPObjectWithPriority(t, trafficSplit)
+
+	testPrefix := "tmpv-"
+	ingName := testPrefix + "def-ing"
+	routeName := testPrefix + "def-route"
+	ns := "default"
+	host := testPrefix + ingestion_test.TestDomain1
+	ingIPAddr := "1.1.1.1"
+	routeIPAddr := "2.2.2.2"
+	ingCluster := "k8s"
+	routeCluster := "oshift"
+	ingHostIPMap := map[string]string{host: ingIPAddr}
+
+	t.Cleanup(func() {
+		k8sDeleteIngress(t, clusterClients[K8s], ingName, ns)
+		oshiftDeleteRoute(t, clusterClients[Oshift], routeName, ns)
+	})
+
+	g := gomega.NewGomegaWithT(t)
+	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
+		ingHostIPMap, false)
+	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
+		routeCluster, host, routeIPAddr, false)
+
+	var expectedMembers []nodes.AviGSK8sObj
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster,
+		int32(k8sWeight), int32(k8sPriority)))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster,
+		int32(oshiftWeight), int32(oshiftPriority)))
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, host, utils.ADMIN_NS, nil, nil, nil, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	updTrafficSplit := []gdpalphav2.TrafficSplitElem{
+		{
+			Cluster:  K8sContext,
+			Weight:   k8sWeight,
+			Priority: k8sPriorityUpdated,
+		},
+	}
+	_, err := UpdateAndVerifyTestGDPPrioritySuccess(t, gdpObj.Name, gdpObj.Namespace, updTrafficSplit)
+	if err != nil {
+		t.Fatalf("error while updating and verifying GDP object: %v", err)
+	}
+	t.Logf("will update the priority in GDP for k8s cluster")
+	var updatedGSMembers []nodes.AviGSK8sObj
+	updatedGSMembers = append(updatedGSMembers, getTestGSMemberFromIng(t, ingObj, ingCluster,
+		int32(k8sWeight), int32(k8sPriorityUpdated)))
+	updatedGSMembers = append(updatedGSMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster,
+		int32(oshiftWeight), int32(oshiftPriority)))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, updatedGSMembers, host, utils.ADMIN_NS, nil, nil, nil, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}

--- a/helm/amko/crds/gdp_def.yaml
+++ b/helm/amko/crds/gdp_def.yaml
@@ -104,6 +104,12 @@ spec:
                       type: integer
                       minimum : 1
                       maximum: 20
+                    priority:
+                      description: "Based on the given priority, this member will be grouped in a pool"
+                      type: integer
+                      minimum: 0
+                      maximum: 100
+                      default: 10
                 type: array
           status:
             type: "object"

--- a/helm/amko/crds/gslbhostrule_def.yaml
+++ b/helm/amko/crds/gslbhostrule_def.yaml
@@ -106,6 +106,11 @@ spec:
                       type: integer
                       maximum: 20
                       minimum: 1
+                    priority:
+                      description: "Based on the given priority, this member will be grouped in a pool"
+                      type: integer
+                      minimum: 0
+                      default: 1
           status:
             type: "object"
             properties:

--- a/internal/apis/amko/v1alpha1/types.go
+++ b/internal/apis/amko/v1alpha1/types.go
@@ -84,8 +84,9 @@ type GSLBConfigSpecList struct {
 // TrafficSplitElem determines how much traffic to be routed to a cluster.
 type TrafficSplitElem struct {
 	// Cluster is the cluster context
-	Cluster string `json:"cluster,omitempty"`
-	Weight  uint32 `json:"weight,omitempty"`
+	Cluster  string `json:"cluster,omitempty"`
+	Weight   uint32 `json:"weight,omitempty"`
+	Priority uint32 `json:"priority,omitempty"`
 }
 
 // +genclient

--- a/internal/apis/amko/v1alpha2/types.go
+++ b/internal/apis/amko/v1alpha2/types.go
@@ -97,8 +97,9 @@ const (
 // TrafficSplitElem determines how much traffic to be routed to a cluster.
 type TrafficSplitElem struct {
 	// Cluster is the cluster context
-	Cluster string `json:"cluster,omitempty"`
-	Weight  uint32 `json:"weight,omitempty"`
+	Cluster  string `json:"cluster,omitempty"`
+	Weight   uint32 `json:"weight,omitempty"`
+	Priority uint32 `json:"priority,omitempty"`
 }
 
 // GDPStatus gives the current status of the policy object.


### PR DESCRIPTION
Use case: A user has 3 clusters: `cluster1`, `cluster2` and `cluster3`.
  `cluster3` serves as a backup cluster. `cluster1` and `cluster2` are
  always preferred to serve the traffic. `cluster3` only kicks-in when
  both `cluster1` and `cluster2` are down.

Configuration: This configuration is now supported through the
  `trafficSplit` property in the `GDP` and the `GSLBHostRule` objects:
  ```
  trafficSplit:
    - cluster: cluster1
      weight: 5
      priority: 20
    - cluster: cluster2
      weight: 5
      priority: 20
    - cluster: cluster3
      weight: 5
      priority: 10
  ```
  User can group these clusters into different pools based on the
  values they provide in the `priority` field for each cluster.
  `priority` ranges between 0-100 with these values having special
  meanings:
  - 0: Having a priority of 0 is essentially disabling that pool.
  - 10: Default priority, if the priority is not set for a cluster, a
        default value of 10 is assumed.
  In the above example, `cluster1` and `cluster2` are prioritized before
  `cluster3`.

Changes:
  - Layer1 recieves the GDP and GSLBHostRule object and sets the
    priority in the filter object. CR definition changes include
    GDP and GSLBHostRule objects for the `trafficSplit` field.
  - Layer2 changes involve checksum calculation changes and GS graph
    member changes.
  - Layer3 changes the way we build a GS object from a GS graph. We
    now go through each member and add it to a pool based on a
    priority. The name of the pool is also changed to include the
    priority in the name because for a given GS, priority will always
    be unique. Parsing logic for GS object has also changed to include
    the priority field.

Integration Test Cases:
  - Two clusters with no priority. Default validation.
  - Two clusters with different validitiy.
  - Two clusters, one with a priority and one without.
  - Two clusters, one with a priority and one without, and update the
    priority for the first cluster.

Implements AV-121083, AV-121084, AV-121085 and AV-121086.