### PR TITLE
Take cluster priority into GDP checksum computation

### DIFF
--- a/gslb/gslbutils/gdputils.go
+++ b/gslb/gslbutils/gdputils.go
@@ -359,7 +359,7 @@ func (gf *GlobalFilter) ComputeChecksum() {
 		cksum += utils.Hash(c) + utils.Hash(utils.Stringify(s.SyncVipsOnly))
 	}
 	for _, ts := range gf.TrafficSplit {
-		cksum += utils.Hash(ts.ClusterName + strconv.Itoa(int(ts.Weight)))
+		cksum += utils.Hash(ts.ClusterName + strconv.Itoa(int(ts.Weight)) + strconv.Itoa(int(ts.Priority)))
 	}
 	if gf.SitePersistenceRef != nil {
 		cksum += utils.Hash(*gf.SitePersistenceRef)


### PR DESCRIPTION
The GDP object's checksum computation logic didn't have priority
in the required fields. This meant that any change to any priority
for a cluster in the GDP object wouldn't prompt AMKO to update
the priorities of the GSs.

Also, added an integration test to test this case.

Resolves #AV-123665