### PR TITLE
Delete stale non path based HMs

### DIFF
--- a/gslb/cache/controller_obj_cache.go
+++ b/gslb/cache/controller_obj_cache.go
@@ -600,8 +600,7 @@ func GetDetailsFromAviGSLBFormatted(gsObj models.GslbService) (uint32, []GSMembe
 		return 0, nil, memberObjs, nil, errors.New("groups absent in gslb service")
 	}
 
-	description := *gsObj.Description
-	if description == "" {
+	if gsObj.Description == nil || *gsObj.Description == "" {
 		return 0, nil, memberObjs, nil, errors.New("description absent in gslb service")
 	}
 
@@ -704,7 +703,7 @@ func GetDetailsFromAviGSLBFormatted(gsObj models.GslbService) (uint32, []GSMembe
 			gsMembers = append(gsMembers, gsMember)
 		}
 	}
-	memberObjs, err := parseDescription(description)
+	memberObjs, err := parseDescription(*gsObj.Description)
 	if err != nil {
 		gslbutils.Errf("object: GSLBService, msg: error while parsing description field: %s", err)
 	}


### PR DESCRIPTION
Some non path based HMs were not being deleted.
This issue is seen when AMKO is upgraded from a version using old HM naming convention(non encoded names) to the version using encoded HM name.