### PR TITLE
Fix - AMKO attempts to delete custom HMs & fails to attach default HMs

### DIFF
--- a/gslb/cache/controller_obj_cache.go
+++ b/gslb/cache/controller_obj_cache.go
@@ -111,8 +111,8 @@ func (h *AviHmCache) AviHmCacheGetHmsForGS(tenant, gsName string) []interface{} 
 		if hmKey.Tenant != tenant {
 			continue
 		}
-		searchStr := "--" + gsName
-		if strings.Contains(hmKey.Name, searchStr) {
+		hmObj := v.(*AviHmObj)
+		if strings.Contains(hmObj.Description, gsName) {
 			hmObjs = append(hmObjs, v)
 		}
 	}
@@ -753,13 +753,12 @@ func GetHmDescriptionFromName(hmName string) string {
 }
 
 func GetGSFromHmName(hmName string) (string, error) {
-	// for path based hms
 	hmDesc := GetHmDescriptionFromName(hmName)
-	hmDescriptionSplit := strings.Split(hmDesc, ": ")
-	if len(hmDescriptionSplit) != 5 {
-		return "", fmt.Errorf("hmName: %s, msg: hm description - \"%s\" is malformed, expected a path based hm", hmName, hmDesc)
+	hmDescriptionSplit := strings.Split(hmDesc, "gsname: ")
+	if len(hmDescriptionSplit) != 2 {
+		return "", fmt.Errorf("hmName: %s, msg: hm description - \"%s\" is malformed", hmName, hmDesc)
 	}
-	gsNameField := strings.Split(hmDescriptionSplit[2], ",")
+	gsNameField := strings.Split(hmDescriptionSplit[1], ",")
 	gsName := strings.Trim(gsNameField[0], " ")
 	return gsName, nil
 

--- a/gslb/nodes/avi_model_nodes.go
+++ b/gslb/nodes/avi_model_nodes.go
@@ -148,6 +148,9 @@ func (hm HealthMonitor) GetHMDescription(gsName string) []string {
 	descPrefix := CreatedByAMKO + ", gsname: " + gsName
 	desc = append(desc, descPrefix)
 	if hm.Type == NonPathHM {
+		if hm.Name == gslbutils.SystemGslbHealthMonitorPassthrough {
+			return []string{CreatedByAMKO}
+		}
 		return desc
 	} else if hm.Type == PathHM {
 		for _, pathHm := range hm.PathHM {
@@ -334,6 +337,7 @@ func (v *AviGSObjectGraph) buildHmPathList() {
 			v.Hm.PathHM = append(v.Hm.PathHM, pathHM)
 		}
 	}
+	v.Hm.Type = PathHM
 	gslbutils.Debugf("gsName: %s, pathHMList: %v, msg: rebuilt path list for GS", v.Name, v.Hm.PathHM)
 }
 

--- a/gslb/test/integration/third_party_vips/ingress_test.go
+++ b/gslb/test/integration/third_party_vips/ingress_test.go
@@ -102,6 +102,9 @@ func PostHMHandlerSendOK(data []byte, w http.ResponseWriter) bool {
 		gslbutils.Errf("[custom post handler]")
 	}
 	uuid := GetTestUuid(HmType, *resp.Name)
+	url := fmt.Sprintf("https://localhost/api/healthmonitor/healthmonitor-%s#%s",
+		*resp.Name+uuid, *resp.Name)
+	resp.URL = &url
 	resp.UUID = &uuid
 	finalResponse, _ := json.Marshal(resp)
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
This PR fixes 2 bugs: 

1. AMKO attempted to delete these custom HMs when updating the Gslb services. 
    AMKO also failed to attach default HMs for these gslb services.
2. Description of passthrough route Health monitors was similar to other non path HMs (`createdby: amko, gsname: <gsname>`). This has been changed to `createdby: amko`

How to reproduce bug-1? 
1. Create gdp with custom HM refs
2. Create ingress/route/loadbalancer service
3. Wait for gslb services to be created
4. Remove the custom HM refs from the GDP object
