### PR TITLE
Handle HMs with non-encoded naming convention

### DIFF
--- a/gslb/ingestion/fullsync.go
+++ b/gslb/ingestion/fullsync.go
@@ -399,14 +399,14 @@ func GenerateModels(gsCache *avicache.AviCache) {
 			continue
 		}
 		tenant, hmName := hmKey.Tenant, hmKey.Name
-		gsName, err := avicache.GetGSFromHmName(hmName)
+		gsName, gen, err := avicache.GetGSFromHmName(hmName)
 		if err != nil {
-			gslbutils.Debugf("key: %v, msg: can't get gs name from hm, err : %v", hmKey, err)
+			gslbutils.Logf("key: %v, msg: can't get gs name from hm, err : %v", hmKey, err)
 			continue
 		}
 		gsKey := tenant + "/" + gsName
 		found, _ := agl.Get(gsKey)
-		if found {
+		if found && gen == 1 {
 			continue
 		}
 		gslbutils.Logf("key: %v, msg: didn't get a GS in the model cache", gsKey)


### PR DESCRIPTION
With this PR, AMKO can handle HMs with non-encoded naming convention.
HMs that are created by amko, but their GSes do not exists anymore are deleted.