### PR TITLE
Add get/list permissions for pods

### DIFF
--- a/helm/amko/templates/clusterrole.yaml
+++ b/helm/amko/templates/clusterrole.yaml
@@ -13,7 +13,7 @@ rules:
     resources: ["routes"]
     verbs: ["get","watch","list"]
   - apiGroups: [""]
-    resources: ["services", "secrets", "namespaces"]
+    resources: ["services", "secrets", "namespaces", "pods"]
     verbs: ["get", "watch", "list"]
   - apiGroups: [""]
     resources: ["events"]


### PR DESCRIPTION
Since we use the AMKO pod metadata to record events, we need the
requisite permissions for pods.
Fixes AV-129224.