### PR TITLE
AMKO Fix - LB service Health Monitor Description is empty when shifting from custom HM to default HM

### DIFF
--- a/gslb/nodes/avi_model_nodes.go
+++ b/gslb/nodes/avi_model_nodes.go
@@ -565,6 +565,7 @@ func (v *AviGSObjectGraph) checkAndUpdateNonPathHealthMonitor(objType string, is
 	v.Hm.Name = hmName
 	v.Hm.Port = newPort
 	v.Hm.HMProtocol = hmProtocol
+	v.Hm.Type = NonPathHM
 }
 
 func (v *AviGSObjectGraph) updateGSHmPathListAndProtocol() {


### PR DESCRIPTION
Steps to Reproduce:
1. Create a LB Service with default HM - HM is create as desired.
2. Edit GDP to add custom HMs - GSLB Service is updated with the corresponding HM and the default HM is deleted.
3. Edit GDP and delete the custom HMs - Default HM is created and attached to the GSLB Service. But this HM has an empty description.