### PR TITLE
Fix for AMKO not considering the priority values in gslbhostrule object

### DIFF
--- a/gslb/cache/controller_obj_cache.go
+++ b/gslb/cache/controller_obj_cache.go
@@ -734,8 +734,9 @@ func GetDetailsFromAviGSLBFormatted(gsObj models.GslbService) (uint32, []GSMembe
 				weight = 0
 			}
 			gsMember := GSMember{
-				IPAddr: ipAddr,
-				Weight: weight,
+				IPAddr:   ipAddr,
+				Weight:   weight,
+				Priority: priority,
 			}
 			// Compute which server to add for this member (for checksum calculation)
 			var server string
@@ -973,6 +974,7 @@ func GetDetailsFromAviGSLB(gslbSvcMap map[string]interface{}) (uint32, []GSMembe
 			gsMember := GSMember{
 				IPAddr:     ipAddr,
 				Weight:     weightI,
+				Priority:   priority,
 				Controller: controllerUUID,
 				VsUUID:     vsUUID,
 			}


### PR DESCRIPTION
This PR fixes the one issue in AMKO. The priority values given in the gslbhostrule object were not considered while creating the pools by the AMKO.