### PR TITLE
UTs for HostRule properties supported by multi-fqdn

### DIFF
--- a/gslb/gslbutils/gslbutils.go
+++ b/gslb/gslbutils/gslbutils.go
@@ -698,3 +698,15 @@ func SetDifference(a, b []string) []string {
 	}
 	return setA.Difference(setB).List()
 }
+
+func SetEqual(a, b []string) bool {
+	setA := sets.NewString()
+	for _, s := range a {
+		setA.Insert(s)
+	}
+	setB := sets.NewString()
+	for _, s := range b {
+		setB.Insert(s)
+	}
+	return setA.Equal(setB)
+}

--- a/gslb/gslbutils/gslbutils.go
+++ b/gslb/gslbutils/gslbutils.go
@@ -688,25 +688,13 @@ func GetGslbConfigObjUpdated() bool {
 
 // Difference compares two slices a & b, returns the elements in `a` that aren't in `b`.
 func SetDifference(a, b []string) []string {
-	setA := sets.NewString()
-	for _, s := range a {
-		setA.Insert(s)
-	}
-	setB := sets.NewString()
-	for _, s := range b {
-		setB.Insert(s)
-	}
+	setA := sets.NewString(a...)
+	setB := sets.NewString(b...)
 	return setA.Difference(setB).List()
 }
 
 func SetEqual(a, b []string) bool {
-	setA := sets.NewString()
-	for _, s := range a {
-		setA.Insert(s)
-	}
-	setB := sets.NewString()
-	for _, s := range b {
-		setB.Insert(s)
-	}
+	setA := sets.NewString(a...)
+	setB := sets.NewString(b...)
 	return setA.Equal(setB)
 }

--- a/gslb/ingestion/event_handlers.go
+++ b/gslb/ingestion/event_handlers.go
@@ -737,7 +737,7 @@ func AddHostRuleEventHandler(numWorkers uint32, c *GSLBMemberController) cache.R
 					return
 				}
 				aliasesChanged := false
-				if len(gslbutils.SetDifference(oldHr.Spec.VirtualHost.Aliases, newHr.Spec.VirtualHost.Aliases)) != 0 {
+				if !gslbutils.SetEqual(oldHr.Spec.VirtualHost.Aliases, newHr.Spec.VirtualHost.Aliases) {
 					aliasesChanged = true
 				}
 				if gslbutils.GetCustomFqdnMode() {
@@ -746,8 +746,8 @@ func AddHostRuleEventHandler(numWorkers uint32, c *GSLBMemberController) cache.R
 						gFqdnChanged = true
 					}
 					// the update can be of 3 types
-					if aliasesChanged && !gFqdnChanged {
-						// case 1: Only the aliases have changed
+					if aliasesChanged && !gFqdnChanged && newHr.Spec.VirtualHost.Gslb.IncludeAliases {
+						// case 1: Only the aliases have changed and includeAliases = true
 						HandleHostRuleAliasChange(newGFqdn, c.name, oldHr.Spec.VirtualHost.Aliases, newHr.Spec.VirtualHost.Aliases)
 					} else if gFqdnChanged && !aliasesChanged || aliasesChanged && gFqdnChanged {
 						// This handles 2 cases
@@ -765,7 +765,7 @@ func AddHostRuleEventHandler(numWorkers uint32, c *GSLBMemberController) cache.R
 						if newHr.Spec.VirtualHost.Gslb.IncludeAliases {
 							gsDomainNameMap.AddUpdateGSToDomainNameMapping(newGFqdn, c.name, newHr.Spec.VirtualHost.Aliases)
 						} else {
-							gsDomainNameMap.DeleteGSToDomainNameMapping(newGFqdn, c.name, oldHr.Spec.VirtualHost.Aliases)
+							gsDomainNameMap.DeleteGSToDomainNameMapping(oldGFqdn, c.name, oldHr.Spec.VirtualHost.Aliases)
 						}
 					}
 					DeleteFromHostRuleStore(hrStore, oldHr, c.name)

--- a/gslb/ingestion/member_controllers.go
+++ b/gslb/ingestion/member_controllers.go
@@ -225,7 +225,7 @@ func isHostRuleUpdated(oldHr *akov1alpha1.HostRule, newHr *akov1alpha1.HostRule)
 	if oldHr.Spec.VirtualHost.TLS != newHr.Spec.VirtualHost.TLS {
 		return true
 	}
-	if len(gslbutils.SetDifference(oldHr.Spec.VirtualHost.Aliases, newHr.Spec.VirtualHost.Aliases)) != 0 {
+	if !gslbutils.SetEqual(oldHr.Spec.VirtualHost.Aliases, newHr.Spec.VirtualHost.Aliases) {
 		return true
 	}
 	if oldHr.Spec.VirtualHost.Gslb.IncludeAliases != newHr.Spec.VirtualHost.Gslb.IncludeAliases {

--- a/gslb/test/integration/custom_fqdn/hostrule_test.go
+++ b/gslb/test/integration/custom_fqdn/hostrule_test.go
@@ -32,11 +32,16 @@ import (
 )
 
 var (
-	routeCluster = "oshift"
-	ingCluster   = "k8s"
+	routeCluster    = "oshift"
+	ingCluster      = "k8s"
+	hmRefs          = []string{"my-hm1"}
+	hrNameK8s       = ""
+	hrNameOC        = ""
+	gfqdn           = ""
+	expectedMembers = []nodes.AviGSK8sObj{}
 )
 
-func getTestGDP(t *testing.T, name, ns string) *gdpalphav2.GlobalDeploymentPolicy {
+func GetTestGDP(t *testing.T, name, ns string) *gdpalphav2.GlobalDeploymentPolicy {
 	gdp, err := gslbutils.AMKOControlConfig().GDPClientset().AmkoV1alpha2().GlobalDeploymentPolicies(ns).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("failed to get GDP object %s: %v", name, err)
@@ -44,7 +49,7 @@ func getTestGDP(t *testing.T, name, ns string) *gdpalphav2.GlobalDeploymentPolic
 	return gdp
 }
 
-func updateTestGDP(t *testing.T, gdp *gdpalphav2.GlobalDeploymentPolicy) *gdpalphav2.GlobalDeploymentPolicy {
+func UpdateTestGDP(t *testing.T, gdp *gdpalphav2.GlobalDeploymentPolicy) *gdpalphav2.GlobalDeploymentPolicy {
 	newGdp, err := gslbutils.AMKOControlConfig().GDPClientset().AmkoV1alpha2().GlobalDeploymentPolicies(gdp.Namespace).Update(context.TODO(), gdp, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("update on GDP %v failed with %v", gdp, err)
@@ -53,7 +58,7 @@ func updateTestGDP(t *testing.T, gdp *gdpalphav2.GlobalDeploymentPolicy) *gdpalp
 	return newGdp
 }
 
-func addIngressAndRouteObjects(t *testing.T, testPrefix string) (*networkingv1.Ingress, *routev1.Route) {
+func AddIngressAndRouteObjects(t *testing.T, testPrefix string) (*networkingv1.Ingress, *routev1.Route) {
 	ingName := testPrefix + "def-ing"
 	routeName := testPrefix + "def-route"
 	ns := "default"
@@ -74,7 +79,17 @@ func addIngressAndRouteObjects(t *testing.T, testPrefix string) (*networkingv1.I
 	return ingObj, routeObj
 }
 
-func addInsecureIngressAndRouteObjects(t *testing.T, testPrefix string) (*networkingv1.Ingress, *routev1.Route) {
+// Initialize HR names, Gfdn, expectedMembers. Creates GDP and return ingObj and routeObj
+func Initialize(t *testing.T, hrPrefix string, hmRefs []string) (*networkingv1.Ingress, *routev1.Route) {
+	hrNameK8s = hrPrefix + "hr"
+	hrNameOC = hrPrefix + "hr"
+	gfqdn = "test-gs.avi.com"
+	expectedMembers = []nodes.AviGSK8sObj{}
+	AddTestGDPWithProperties(t, hmRefs, nil, nil, nil)
+	return AddIngressAndRouteObjects(t, hrPrefix)
+}
+
+func AddInsecureIngressAndRouteObjects(t *testing.T, testPrefix string) (*networkingv1.Ingress, *routev1.Route) {
 	ingName := testPrefix + "def-ing"
 	routeName := testPrefix + "def-route"
 	ns := "default"
@@ -95,7 +110,7 @@ func addInsecureIngressAndRouteObjects(t *testing.T, testPrefix string) (*networ
 	return ingObj, routeObj
 }
 
-func addTestGDPWithProperties(t *testing.T, hmRefs []string, ttl *int, sitePersistence *string, hmTemplate *string) *gdpalphav2.GlobalDeploymentPolicy {
+func AddTestGDPWithProperties(t *testing.T, hmRefs []string, ttl *int, sitePersistence *string, hmTemplate *string) *gdpalphav2.GlobalDeploymentPolicy {
 	gdpObj := GetTestDefaultGDPObject()
 	gdpObj.Spec.MatchRules.AppSelector = gdpalphav2.AppSelector{
 		Label: appLabel,
@@ -120,37 +135,37 @@ func addTestGDPWithProperties(t *testing.T, hmRefs []string, ttl *int, sitePersi
 	return newGDP
 }
 
-// Add ingress and route objects, create a GDP object, create host rules and verify
-func TestHostRuleCreate(t *testing.T) {
-	testPrefix := "hr-"
-	hmRefs := []string{"my-hm1"}
-	hrNameK8s := testPrefix + "hr"
-	hrNameOC := testPrefix + "hr"
-	gfqdn := "test-gs.avi.com"
+/*
+1. create a GDP object
+2. Add ingress and route objects
+3. Test and verify with various cases of hostrule
+*/
 
-	addTestGDPWithProperties(t, hmRefs, nil, nil, nil)
-	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
-
-	var expectedMembers []nodes.AviGSK8sObj
+// Create host rules
+func TestHRCreate(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hr-", hmRefs)
 
 	// create a host rule for the ingress object's hostname, verify GS member
-	k8sHr := getDefaultHostRule(hrNameK8s, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
-		gslbutils.HostRuleAccepted)
+	k8sHr := getHostRuleWithAliasesForCustomFqdn(hrNameK8s, ingCluster, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, true)
 	createHostRule(t, K8s, k8sHr)
 
 	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr}))
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 	// create a host rule for the route object's hostname, verify GS members
-	ocHr := getDefaultHostRule(hrNameOC, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
-		gslbutils.HostRuleAccepted)
+	ocHr := getHostRuleWithAliasesForCustomFqdn(hrNameOC, routeCluster, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, true)
 	createHostRule(t, Oshift, ocHr)
+
 	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr, ocHr}))
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }
 
@@ -162,59 +177,595 @@ func TestHostRuleCreateWithHmTemplateInGDP(t *testing.T) {
 	hrNameOC := testPrefix + "hr"
 	gfqdn := "test-gs.avi.com"
 
-	addTestGDPWithProperties(t, nil, nil, nil, &hmTemplate)
-	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
+	AddTestGDPWithProperties(t, nil, nil, nil, &hmTemplate)
+	ingObj, routeObj := AddIngressAndRouteObjects(t, testPrefix)
 
 	var expectedMembers []nodes.AviGSK8sObj
 	g := gomega.NewGomegaWithT(t)
 
 	// create a host rule for the ingress object's hostname, verify GS member
-	k8sHr := getDefaultHostRule(hrNameK8s, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
-		gslbutils.HostRuleAccepted)
+	k8sHr := getHostRuleWithAliasesForCustomFqdn(hrNameK8s, ingCluster, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, true)
 	createHostRule(t, K8s, k8sHr)
 
 	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, nil, &hmTemplate, nil, nil)
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, nil, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr}), nil, &hmTemplate)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 	// create a host rule for the route object's hostname, verify GS members
-	ocHr := getDefaultHostRule(hrNameOC, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
-		gslbutils.HostRuleAccepted)
+	ocHr := getHostRuleWithAliasesForCustomFqdn(hrNameOC, routeCluster, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, true)
 	createHostRule(t, Oshift, ocHr)
 	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, nil, &hmTemplate, nil, nil)
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, nil, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr, ocHr}), nil, &hmTemplate)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }
 
-// Add ingress and route objects, create a GDP object, create invalid host rules, update them to
-// valid state
-func TestHostRuleInvalidToValid(t *testing.T) {
-	testPrefix := "hriv-"
-	hmRefs := []string{"my-hm1"}
-	hrNameK8s := testPrefix + "hr"
-	hrNameOC := testPrefix + "hr"
-	gfqdn := "test-gs.avi.com"
-
-	addTestGDPWithProperties(t, hmRefs, nil, nil, nil)
-	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
-
-	var expectedMembers []nodes.AviGSK8sObj
+// Create host rules with includeAliases = false
+func TestHRCreateUnsetIncludeAliases(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hr-", hmRefs)
+
+	// create a host rule for the ingress object's hostname with includeAliases = false, verify GS member
+	k8sHr := getHostRuleWithAliasesForCustomFqdn(hrNameK8s, ingCluster, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, false)
+	createHostRule(t, K8s, k8sHr)
+
+	defaultDomainNames := []string{gfqdn}
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, defaultDomainNames)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// create a host rule for the route object's hostname with includeAliases = false, verify GS members
+	ocHr := getHostRuleWithAliasesForCustomFqdn(hrNameOC, routeCluster, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, false)
+	createHostRule(t, Oshift, ocHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, defaultDomainNames)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Create host rules and remove all aliases
+func TestHRRemoveAliases(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hr-", hmRefs)
+
+	// create a host rule for the ingress object's hostname, verify GS member
+	k8sHr := getHostRuleWithAliasesForCustomFqdn(hrNameK8s, ingCluster, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, true)
+	createHostRule(t, K8s, k8sHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// create a host rule for the route object's hostname, verify GS members
+	ocHr := getHostRuleWithAliasesForCustomFqdn(hrNameOC, routeCluster, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, true)
+	createHostRule(t, Oshift, ocHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr, ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Update HostRule to remove all aliases
+	newK8sHr := getTestHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	newK8sHr.Spec.VirtualHost.Aliases = []string{}
+	updateHostRule(t, K8s, newK8sHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Update HostRule to remove all aliases
+	newOcHr := getTestHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	newOcHr.Spec.VirtualHost.Aliases = []string{}
+	updateHostRule(t, Oshift, newOcHr)
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, []string{gfqdn})
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Create host rules and toggle the includeAliases flag from true -> false
+func TestHRCreateToggleIncludeAliases(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hr-", hmRefs)
+
+	// create a host rule for the ingress object's hostname, verify GS member
+	k8sHr := getHostRuleWithAliasesForCustomFqdn(hrNameK8s, ingCluster, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, true)
+	createHostRule(t, K8s, k8sHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// create a host rule for the route object's hostname, verify GS members
+	ocHr := getHostRuleWithAliasesForCustomFqdn(hrNameOC, routeCluster, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, true)
+	createHostRule(t, Oshift, ocHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr, ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Update HostRule to toggle includeAliases
+	newK8sHr := getTestHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	newK8sHr.Spec.VirtualHost.Gslb.IncludeAliases = false
+	updateHostRule(t, K8s, newK8sHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Update HostRule to toggle includeAliases
+	newOcHr := getTestHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	newOcHr.Spec.VirtualHost.Gslb.IncludeAliases = false
+	updateHostRule(t, Oshift, newOcHr)
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, []string{gfqdn})
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Create, update gqfdn and delete host rules
+func TestHRCreateUpdateGfdnDelete(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hr-", hmRefs)
+
+	// create a host rule for the ingress object's hostname, verify GS member
+	k8sHr := getHostRuleWithAliasesForCustomFqdn(hrNameK8s, ingCluster, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, true)
+	createHostRule(t, K8s, k8sHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// create a host rule for the route object's hostname, verify GS members
+	ocHr := getHostRuleWithAliasesForCustomFqdn(hrNameOC, routeCluster, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, true)
+	createHostRule(t, Oshift, ocHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr, ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	newgfqdn := "new-" + gfqdn
+	// Update gfqdn for hostrule
+	newK8sHr := getTestHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	newK8sHr.Spec.VirtualHost.Gslb.Fqdn = newgfqdn
+	updateHostRule(t, K8s, newK8sHr)
+
+	expectedMembers = append([]nodes.AviGSK8sObj{}, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, newgfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(newgfqdn, []*akov1alpha1.HostRule{newK8sHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Update gfqdn for hostrule
+	newOcHr := getTestHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	newOcHr.Spec.VirtualHost.Gslb.Fqdn = newgfqdn
+	updateHostRule(t, Oshift, newOcHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, newgfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(newgfqdn, []*akov1alpha1.HostRule{newK8sHr, newOcHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Delete HostRule
+	deleteHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	deleteHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	g.Eventually(func() bool {
+		return verifyGSDoesNotExist(t, newgfqdn)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Create, update gqfdn and delete host rules with includeAliases = false
+func TestHRCreateUpdateGfdnDeleteUnsetIncludeAliases(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hr-", hmRefs)
+
+	// create a host rule for the ingress object's hostname, verify GS member
+	k8sHr := getHostRuleWithAliasesForCustomFqdn(hrNameK8s, ingCluster, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, false)
+	createHostRule(t, K8s, k8sHr)
+
+	defaultDomainNames := []string{gfqdn}
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, defaultDomainNames)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// create a host rule for the route object's hostname, verify GS members
+	ocHr := getHostRuleWithAliasesForCustomFqdn(hrNameOC, routeCluster, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, false)
+	createHostRule(t, Oshift, ocHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, defaultDomainNames)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Update gfqdn for hostrule
+	newgfqdn := "new-" + gfqdn
+	newK8sHr := getTestHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	newK8sHr.Spec.VirtualHost.Gslb.Fqdn = newgfqdn
+	updateHostRule(t, K8s, newK8sHr)
+
+	expectedMembers = append([]nodes.AviGSK8sObj{}, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	defaultDomainNames = []string{newgfqdn}
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, newgfqdn, utils.ADMIN_NS, hmRefs, nil, nil, defaultDomainNames)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Update gfqdn for hostrule
+	newOcHr := getTestHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	newOcHr.Spec.VirtualHost.Gslb.Fqdn = newgfqdn
+	updateHostRule(t, Oshift, newOcHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, newgfqdn, utils.ADMIN_NS, hmRefs, nil, nil, defaultDomainNames)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Delete HostRule
+	deleteHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	deleteHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	g.Eventually(func() bool {
+		return verifyGSDoesNotExist(t, newgfqdn)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Create, update aliases and delete host rules
+// Update cases
+// 1. appending new aliases
+// 2. replacing old aliases
+// 3. removing some of the old aliases
+func TestHRCreateUpdateAliasesDelete(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hr-", hmRefs)
+
+	// create a host rule for the ingress object's hostname, verify GS member
+	k8sHr := getHostRuleWithAliasesForCustomFqdn(hrNameK8s, ingCluster, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, true)
+	createHostRule(t, K8s, k8sHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// create a host rule for the route object's hostname, verify GS members
+	ocHr := getHostRuleWithAliasesForCustomFqdn(hrNameOC, routeCluster, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, true)
+	createHostRule(t, Oshift, ocHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr, ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// update case 1 - Appending new aliases
+	newK8sHr := getTestHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	newK8sHr.Spec.VirtualHost.Aliases = append(newK8sHr.Spec.VirtualHost.Aliases, []string{"newK8s_alias1.com", "newK8s_alias2.com"}...)
+	updateHostRule(t, K8s, newK8sHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{newK8sHr, ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// update case 2 - replacing old aliases
+	newOcHr := getTestHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	newOcHr.Spec.VirtualHost.Aliases = []string{"newOc_alias1.com", "newOc_alias2.com"}
+	updateHostRule(t, Oshift, newOcHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{newK8sHr, newOcHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// update case 3 - removing some old aliases
+	newK8sHr = getTestHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	// old aliases = {k8s_alias1.avi.com, k8s_alias2.avi.com, k8s_alias3.avi.com, newK8s_alias1.com, newK8s_alias2.com}
+	newK8sHr.Spec.VirtualHost.Aliases = []string{"k8s_alias3.avi.com", "newK8s_alias1.com", "newK8s_alias2.com"}
+	updateHostRule(t, K8s, newK8sHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{newK8sHr, newOcHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Delete HostRule
+	deleteHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	deleteHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	g.Eventually(func() bool {
+		return verifyGSDoesNotExist(t, gfqdn)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// // Create, update aliases and delete host rules with includeAliases = false
+// Update cases
+// 1. appending new aliases
+// 2. replacing old aliases
+// 3. removing some of the old aliases
+func TestHRCreateUpdateAliasesDeleteUnsetIncludeAliases(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hr-", hmRefs)
+
+	// create a host rule for the ingress object's hostname, verify GS member
+	k8sHr := getHostRuleWithAliasesForCustomFqdn(hrNameK8s, ingCluster, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, false)
+	createHostRule(t, K8s, k8sHr)
+
+	defaultDomainNames := []string{gfqdn}
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, defaultDomainNames)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// create a host rule for the route object's hostname, verify GS members
+	ocHr := getHostRuleWithAliasesForCustomFqdn(hrNameOC, routeCluster, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, false)
+	createHostRule(t, Oshift, ocHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, defaultDomainNames)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// update case 1 - Appending new aliases
+	newK8sHr := getTestHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	newK8sHr.Spec.VirtualHost.Aliases = append(newK8sHr.Spec.VirtualHost.Aliases, []string{"newK8s_alias1.com", "newK8s_alias2.com"}...)
+	updateHostRule(t, K8s, newK8sHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, defaultDomainNames)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// update case 2 - replacing old aliases
+	newOcHr := getTestHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	newOcHr.Spec.VirtualHost.Aliases = []string{"newOc_alias1.com", "newOc_alias2.com"}
+	updateHostRule(t, Oshift, newOcHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, defaultDomainNames)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// update case 3 - removing some old aliases
+	newK8sHr = getTestHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	// old aliases = {k8s_alias1.avi.com, k8s_alias2.avi.com, k8s_alias3.avi.com, newK8s_alias1.com, newK8s_alias2.com}
+	newK8sHr.Spec.VirtualHost.Aliases = []string{"k8s_alias3.avi.com", "newK8s_alias1.com", "newK8s_alias2.com"}
+	updateHostRule(t, K8s, newK8sHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, defaultDomainNames)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Delete HostRule
+	deleteHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	deleteHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	g.Eventually(func() bool {
+		return verifyGSDoesNotExist(t, gfqdn)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Create, update aliases to have duplicate aliases in the same cluster
+func TestHRCreateUpdateDuplicateAliasesInCluster(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hr-", hmRefs)
+
+	// create a host rule for the ingress object's hostname, verify GS member
+	k8sHr := getHostRuleWithAliasesForCustomFqdn(hrNameK8s, ingCluster, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, true)
+	createHostRule(t, K8s, k8sHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// create a host rule for the route object's hostname, verify GS members
+	ocHr := getHostRuleWithAliasesForCustomFqdn(hrNameOC, routeCluster, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, true)
+	createHostRule(t, Oshift, ocHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr, ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Update aliases for k8s hr
+	newK8sHr := getTestHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	newK8sHr.Spec.VirtualHost.Aliases = []string{"dupK8s_alias.avi.com", "dupK8s_alias.avi.com"}
+	newK8sHr.Status.Status = gslbutils.HostRuleRejected
+	updateHostRule(t, K8s, newK8sHr)
+
+	// ingMember is removed from expectedMembers as the hostrule is rejected
+	expectedMembers = []nodes.AviGSK8sObj{getTestGSMemberFromRoute(t, routeObj, routeCluster, 1)}
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Update aliases for openshift hr
+	newOcHr := getTestHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	newOcHr.Spec.VirtualHost.Aliases = []string{"dupOc_alias.avi.com", "dupOc_alias.avi.com"}
+	newOcHr.Status.Status = gslbutils.HostRuleRejected
+	updateHostRule(t, Oshift, newOcHr)
+
+	// since both the hostrules are rejected the corresponding GS is deleted
+	g.Eventually(func() bool {
+		return verifyGSDoesNotExist(t, gfqdn)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Create, update aliases to have duplicate aliases across clusters
+func TestHRCreateUpdateDuplicateAliasesAcrossCluster(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hr-", hmRefs)
+
+	// create a host rule for the ingress object's hostname, verify GS member
+	k8sHr := getHostRuleWithAliasesForCustomFqdn(hrNameK8s, ingCluster, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, true)
+	createHostRule(t, K8s, k8sHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// create a host rule for the route object's hostname, verify GS members
+	ocHr := getHostRuleWithAliasesForCustomFqdn(hrNameOC, routeCluster, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+		gslbutils.HostRuleAccepted, nil, true)
+	createHostRule(t, Oshift, ocHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr, ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Update aliases for k8s hr
+	newK8sHr := getTestHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	newK8sHr.Spec.VirtualHost.Aliases = append(newK8sHr.Spec.VirtualHost.Aliases, []string{"dup_alias.avi.com"}...)
+	updateHostRule(t, K8s, newK8sHr)
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{newK8sHr, ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Update aliases for openshift hr
+	newOcHr := getTestHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	newOcHr.Spec.VirtualHost.Aliases = append(newOcHr.Spec.VirtualHost.Aliases, []string{"dup_alias.avi.com"}...)
+	updateHostRule(t, Oshift, newOcHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{newK8sHr, newOcHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Create host rules with duplicate aliases in the same cluster and delete the HR
+
+func TestHRCreateDeleteDuplicateAliasesInCluster(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hr-", hmRefs)
+
+	// create a host rule for the ingress object's hostname, verify GS member
+	k8sHr := getHostRuleWithAliasesForCustomFqdn(hrNameK8s, ingCluster, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+		gslbutils.HostRuleRejected, []string{"k8s_dup_alias.avi.com", "k8s_dup_alias.avi.com"}, true)
+	createHostRule(t, K8s, k8sHr)
+
+	// since the hostrules is rejected the corresponding GS does not exist
+	g.Eventually(func() bool {
+		return verifyGSDoesNotExist(t, gfqdn)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// create a host rule for the route object's hostname, verify GS members
+	ocHr := getHostRuleWithAliasesForCustomFqdn(hrNameOC, routeCluster, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+		gslbutils.HostRuleRejected, []string{"oc_dup_alias.avi.com", "oc_dup_alias.avi.com"}, true)
+	createHostRule(t, Oshift, ocHr)
+
+	// since the hostrules is rejected the corresponding GS does not exist
+	g.Eventually(func() bool {
+		return verifyGSDoesNotExist(t, gfqdn)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Delete HostRule
+	deleteHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	deleteHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+
+	g.Eventually(func() bool {
+		return verifyGSDoesNotExist(t, gfqdn)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Create host rules with duplicate aliases across clusters and delete the HR
+
+func TestHRCreateDeleteDuplicateAliasesAcrossCluster(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hr-", hmRefs)
+
+	// create a host rule for the ingress object's hostname, verify GS member
+	k8sHr := getHostRuleWithAliasesForCustomFqdn(hrNameK8s, ingCluster, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+		gslbutils.HostRuleAccepted, []string{"k8s_alias1.avi.com", "dup_alias.avi.com"}, true)
+	createHostRule(t, K8s, k8sHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// create a host rule for the route object's hostname, verify GS members
+	ocHr := getHostRuleWithAliasesForCustomFqdn(hrNameOC, routeCluster, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+		gslbutils.HostRuleAccepted, []string{"oshift_alias1.avi.com", "dup_alias.avi.com"}, true)
+	createHostRule(t, Oshift, ocHr)
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr, ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Delete hostrule whose duplicate alias was discarded
+	deleteHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	expectedMembers = []nodes.AviGSK8sObj{getTestGSMemberFromIng(t, ingObj, ingCluster, 1)}
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Delete HostRule
+	deleteHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	g.Eventually(func() bool {
+		return verifyGSDoesNotExist(t, gfqdn)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Create invalid host rules, update them to valid state
+func TestHostRuleInvalidToValidForCustomFqdn(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hriv-", hmRefs)
 
 	// create a invalid host rule for the ingress object's hostname, verify GS member
-	k8sHr := getDefaultHostRule(hrNameK8s, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+	k8sHr := getHostRuleForCustomFqdn(hrNameK8s, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
 		gslbutils.HostRuleRejected)
 	createHostRule(t, K8s, k8sHr)
 
 	// create a host rule for the route object's hostname, verify GS members
-	ocHr := getDefaultHostRule(hrNameOC, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+	ocHr := getHostRuleForCustomFqdn(hrNameOC, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
 		gslbutils.HostRuleAccepted)
 	createHostRule(t, Oshift, ocHr)
 	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{ocHr}))
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 	// update the hostrule to a valid one for the ingress object
@@ -223,42 +774,36 @@ func TestHostRuleInvalidToValid(t *testing.T) {
 	updateHostRule(t, K8s, newK8sHr)
 	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{newK8sHr, ocHr}))
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }
 
 // Add ingress and route objects, create a GDP object, create valid host rules and update them to
 // invalid
-func TestHostRuleValidToInvalid(t *testing.T) {
-	testPrefix := "hrvi-"
-	hmRefs := []string{"my-hm1"}
-	hrNameK8s := testPrefix + "hr"
-	hrNameOC := testPrefix + "hr"
-	gfqdn := "test-gs.avi.com"
-
-	addTestGDPWithProperties(t, hmRefs, nil, nil, nil)
-	ingObj, routeObj := addIngressAndRouteObjects(t, testPrefix)
-
-	var expectedMembers []nodes.AviGSK8sObj
+func TestHostRuleValidToInvalidForCustomFqdn(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hrvi-", hmRefs)
 
 	// create a host rule for the ingress object's hostname, verify GS member
-	k8sHr := getDefaultHostRule(hrNameK8s, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+	k8sHr := getHostRuleForCustomFqdn(hrNameK8s, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
 		gslbutils.HostRuleAccepted)
 	createHostRule(t, K8s, k8sHr)
 
 	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr}))
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 	// create a host rule for the route object's hostname, verify GS members
-	ocHr := getDefaultHostRule(hrNameOC, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+	ocHr := getHostRuleForCustomFqdn(hrNameOC, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
 		gslbutils.HostRuleAccepted)
 	createHostRule(t, Oshift, ocHr)
 	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1))
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr, ocHr}))
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 	// change the ingress's host rule to invalid
@@ -269,43 +814,46 @@ func TestHostRuleValidToInvalid(t *testing.T) {
 	// GS graph should now have only one member
 	expectedMembers = []nodes.AviGSK8sObj{getTestGSMemberFromRoute(t, routeObj, routeCluster, 1)}
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{ocHr}))
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }
 
 // Add an ingress object, create a GDP object, create multiple host rules, one accepted and other
 // rejected
-func TestHostRuleMultiple(t *testing.T) {
-	testPrefix := "hr-"
+func TestHostRuleMultipleForCustomFqdn(t *testing.T) {
+	testPrefix := "hrm-"
 	hmRefs := []string{"my-hm1"}
 	hrNameK8s1 := testPrefix + "hr1"
 	hrNameK8s2 := testPrefix + "hr2"
 	gfqdn1 := "test-gs.avi.com"
 	gfqdn2 := "test-gs2.avi.com"
 
-	addTestGDPWithProperties(t, hmRefs, nil, nil, nil)
-	ingObj, _ := addIngressAndRouteObjects(t, testPrefix)
+	AddTestGDPWithProperties(t, hmRefs, nil, nil, nil)
+	ingObj, _ := AddIngressAndRouteObjects(t, testPrefix)
 
 	var expectedMembers []nodes.AviGSK8sObj
 	g := gomega.NewGomegaWithT(t)
 
 	// create a host rule for the ingress object's hostname, verify GS member
-	k8sHr := getDefaultHostRule(hrNameK8s1, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn1,
+	k8sHr := getHostRuleForCustomFqdn(hrNameK8s1, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn1,
 		gslbutils.HostRuleAccepted)
 	createHostRule(t, K8s, k8sHr)
 
 	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1))
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, gfqdn1, utils.ADMIN_NS, hmRefs, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, gfqdn1, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn1, []*akov1alpha1.HostRule{k8sHr}))
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
-	newK8sHr := getDefaultHostRule(hrNameK8s2, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn2,
+	newK8sHr := getHostRuleForCustomFqdn(hrNameK8s2, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn2,
 		gslbutils.HostRuleRejected)
 	createHostRule(t, K8s, newK8sHr)
 
 	// there shouldn't be any change in the GS graph
 	g.Eventually(func() bool {
-		return verifyGSMembers(t, expectedMembers, gfqdn1, utils.ADMIN_NS, hmRefs, nil, nil, nil)
+		return verifyGSMembers(t, expectedMembers, gfqdn1, utils.ADMIN_NS, hmRefs, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn1, []*akov1alpha1.HostRule{k8sHr}))
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }
 
@@ -317,22 +865,22 @@ func TestHostRuleMultiple(t *testing.T) {
 // 3. Verify the members and HTTP health monitor for GS.
 // 4. Update the hostrules with TLS fields.
 // 5. Verify the members and HTTPS health monitor for GS.
-func TestHostRuleInsecureToSecure(t *testing.T) {
+func TestHostRuleInsecureToSecureForCustomFqdn(t *testing.T) {
 	testPrefix := "hris-"
 	hrNameK8s := testPrefix + "hr"
 	hrNameOC := testPrefix + "hr"
 	gfqdn := "test-gs.avi.com"
 
-	addTestGDPWithProperties(t, nil, nil, nil, nil)
-	ingObj, routeObj := addInsecureIngressAndRouteObjects(t, testPrefix)
+	AddTestGDPWithProperties(t, nil, nil, nil, nil)
+	ingObj, routeObj := AddInsecureIngressAndRouteObjects(t, testPrefix)
 
 	var expectedMembers []nodes.AviGSK8sObj
 	g := gomega.NewGomegaWithT(t)
 
-	k8sHr := getDefaultHostRule(hrNameK8s, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+	k8sHr := getHostRuleForCustomFqdn(hrNameK8s, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
 		gslbutils.HostRuleAccepted)
 	createHostRule(t, K8s, k8sHr)
-	ocHr := getDefaultHostRule(hrNameOC, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+	ocHr := getHostRuleForCustomFqdn(hrNameOC, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
 		gslbutils.HostRuleAccepted)
 	createHostRule(t, Oshift, ocHr)
 
@@ -342,7 +890,8 @@ func TestHostRuleInsecureToSecure(t *testing.T) {
 	g.Eventually(func() bool {
 		// the last parameter below indicates the type of health monitor (HTTP/HTTPS), in this case,
 		// it must be `false` indicating HTTP type.
-		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, nil, nil, nil, nil, false)
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, nil, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr, ocHr}), false)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 	newK8sHr := getTestHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
@@ -362,7 +911,8 @@ func TestHostRuleInsecureToSecure(t *testing.T) {
 	g.Eventually(func() bool {
 		// the last parameter below indicates the type of health monitor (HTTP/HTTPS), in this case,
 		// it must be `true` indicating HTTPS type.
-		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, nil, nil, nil, nil, true)
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, nil, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{newK8sHr, newOcHr}), true)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }
 
@@ -374,25 +924,25 @@ func TestHostRuleInsecureToSecure(t *testing.T) {
 // 3. Verify the members and HTTPS health monitor for GS.
 // 4. Update the hostrules with TLS fields removed.
 // 5. Verify the members and HTTP health monitor for GS.
-func TestHostRuleSecureToInsecure(t *testing.T) {
+func TestHostRuleSecureToInsecureForCustomFqdn(t *testing.T) {
 	testPrefix := "hrsi-"
 	hrNameK8s := testPrefix + "hr"
 	hrNameOC := testPrefix + "hr"
 	gfqdn := "test-gs.avi.com"
 
-	addTestGDPWithProperties(t, nil, nil, nil, nil)
-	ingObj, routeObj := addInsecureIngressAndRouteObjects(t, testPrefix)
+	AddTestGDPWithProperties(t, nil, nil, nil, nil)
+	ingObj, routeObj := AddInsecureIngressAndRouteObjects(t, testPrefix)
 
 	var expectedMembers []nodes.AviGSK8sObj
 	g := gomega.NewGomegaWithT(t)
 
 	testCert := akov1alpha1.HostRuleSSLKeyCertificate{Name: "test-cert", Type: "test-type"}
 
-	k8sHr := getDefaultHostRule(hrNameK8s, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
+	k8sHr := getHostRuleForCustomFqdn(hrNameK8s, ingObj.Namespace, ingObj.Spec.Rules[0].Host, gfqdn,
 		gslbutils.HostRuleAccepted)
 	k8sHr.Spec.VirtualHost.TLS.SSLKeyCertificate = testCert
 	createHostRule(t, K8s, k8sHr)
-	ocHr := getDefaultHostRule(hrNameOC, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
+	ocHr := getHostRuleForCustomFqdn(hrNameOC, routeObj.Namespace, routeObj.Spec.Host, gfqdn,
 		gslbutils.HostRuleAccepted)
 	ocHr.Spec.VirtualHost.TLS.SSLKeyCertificate = testCert
 	createHostRule(t, Oshift, ocHr)
@@ -407,7 +957,8 @@ func TestHostRuleSecureToInsecure(t *testing.T) {
 	g.Eventually(func() bool {
 		// the last parameter below indicates the type of health monitor (HTTP/HTTPS), in this case,
 		// it must be `true` indicating HTTPS type.
-		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, nil, nil, nil, nil, true)
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, nil, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{k8sHr, ocHr}), true)
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 	// remove the TLS fields from the hostrules
@@ -427,6 +978,7 @@ func TestHostRuleSecureToInsecure(t *testing.T) {
 	g.Eventually(func() bool {
 		// the last parameter below indicates the type of health monitor (HTTP/HTTPS), in this case,
 		// it must be `false` indicating HTTP type.
-		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, nil, nil, nil, nil, false)
+		return verifyGSMembers(t, expectedMembers, gfqdn, utils.ADMIN_NS, nil, nil, nil,
+			getDefaultExpectedDomainNames(gfqdn, []*akov1alpha1.HostRule{newK8sHr, newOcHr}), false)
 	}, 10*time.Second, 1*time.Second).Should(gomega.Equal(true))
 }

--- a/gslb/test/integration/third_party_vips/hostrule_aliases_test.go
+++ b/gslb/test/integration/third_party_vips/hostrule_aliases_test.go
@@ -1,0 +1,531 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package third_party_vips
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/gslbutils"
+	"github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/nodes"
+	ingestion_test "github.com/vmware/global-load-balancing-services-for-kubernetes/gslb/test/ingestion"
+	gdpalphav2 "github.com/vmware/global-load-balancing-services-for-kubernetes/pkg/apis/amko/v1alpha2"
+	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1alpha1"
+	hrcs "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1alpha1/clientset/versioned"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+	networkingv1 "k8s.io/api/networking/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+/*
+This test file takes care of Hostrule variations in a non custom_fqdn mode
+*/
+
+var (
+	hmRefs          = []string{"my-hm1"}
+	expectedMembers = []nodes.AviGSK8sObj{}
+	hrNameK8s       = ""
+	hrNameOC        = ""
+	hrIRPath        = []string{"/foo"}
+	hrTls           = false
+)
+
+func AddTestGDPWithProperties(t *testing.T, hmRefs []string, ttl *int, sitePersistence *string, hmTemplate *string) *gdpalphav2.GlobalDeploymentPolicy {
+	gdpObj := GetTestDefaultGDPObject()
+	gdpObj.Spec.MatchRules.AppSelector = gdpalphav2.AppSelector{
+		Label: appLabel,
+	}
+	gdpObj.Spec.MatchClusters = []gdpalphav2.ClusterProperty{
+		{Cluster: K8sContext}, {Cluster: OshiftContext},
+	}
+	gdpObj.Spec.HealthMonitorRefs = hmRefs
+	gdpObj.Spec.TTL = ttl
+	gdpObj.Spec.SitePersistenceRef = sitePersistence
+	gdpObj.Spec.HealthMonitorTemplate = hmTemplate
+
+	newGDP, err := AddAndVerifyTestGDPSuccess(t, gdpObj)
+	if err != nil {
+		t.Fatalf("error in creating and verifying GDP object %v: %v", newGDP, err)
+	}
+
+	t.Cleanup(func() {
+		DeleteTestGDP(t, gdpObj.Namespace, gdpObj.Name)
+	})
+
+	return newGDP
+}
+
+func AddIngressAndRouteObjects(t *testing.T, testPrefix string) (*networkingv1.Ingress, *routev1.Route) {
+	ingName := testPrefix + "def-ing"
+	routeName := testPrefix + "def-route"
+	ns := "default"
+	host := testPrefix + ingestion_test.TestDomain1
+	ingIPAddr := "10.10.100.1"
+	routeIPAddr := "10.10.200.1"
+	ingHostIPMap := map[string]string{host: ingIPAddr}
+
+	t.Cleanup(func() {
+		k8sDeleteIngress(t, clusterClients[K8s], ingName, ns)
+		oshiftDeleteRoute(t, clusterClients[Oshift], routeName, ns)
+	})
+
+	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
+		ingHostIPMap, hrIRPath, true)
+	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
+		routeCluster, host, routeIPAddr, hrIRPath[0], true)
+	return ingObj, routeObj
+}
+
+// Initialize HR names, Gfdn, expectedMembers. Creates GDP and return ingObj and routeObj
+func Initialize(t *testing.T, hrPrefix string, hmRefs []string) (*networkingv1.Ingress, *routev1.Route) {
+	hrNameK8s = hrPrefix + "hr"
+	hrNameOC = hrPrefix + "hr"
+	expectedMembers = []nodes.AviGSK8sObj{}
+	AddTestGDPWithProperties(t, hmRefs, nil, nil, nil)
+	return AddIngressAndRouteObjects(t, hrPrefix)
+}
+
+func GetDefaultAliases(objType string) []string {
+	return []string{
+		objType + "_alias1" + ".avi.com",
+		objType + "_alias2" + ".avi.com",
+		objType + "_alias3" + ".avi.com",
+	}
+}
+
+func GetDefaultHostRule(name, ns, lfqdn, status string) *akov1alpha1.HostRule {
+	return &akov1alpha1.HostRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: akov1alpha1.HostRuleSpec{
+			VirtualHost: akov1alpha1.HostRuleVirtualHost{
+				Fqdn: lfqdn,
+			},
+		},
+		Status: akov1alpha1.HostRuleStatus{
+			Status: status,
+		},
+	}
+}
+
+func GetHostRuleWithAliases(name, objType, ns, lfqdn, status string, aliases []string) *akov1alpha1.HostRule {
+	if aliases == nil {
+		aliases = GetDefaultAliases(objType)
+	}
+	hr := GetDefaultHostRule(name, ns, lfqdn, status)
+	hr.Spec.VirtualHost.Aliases = aliases
+	return hr
+}
+
+func DeleteHostRule(t *testing.T, cluster int, name, ns string) {
+	hrClient, err := hrcs.NewForConfig(cfgs[cluster])
+	if err != nil {
+		t.Fatalf("error in getting hostrule client for cluster %d: %v", cluster, err)
+	}
+
+	err = hrClient.AkoV1alpha1().HostRules(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		t.Fatalf("error in deleting hostrule for cluster %d: %v", cluster, err)
+	}
+}
+
+func CreateHostRule(t *testing.T, cluster int, hr *akov1alpha1.HostRule) *akov1alpha1.HostRule {
+	hrClient, err := hrcs.NewForConfig(cfgs[cluster])
+	if err != nil {
+		t.Fatalf("error in getting hostrule client for cluster %d: %v", cluster, err)
+	}
+
+	newHr, err := hrClient.AkoV1alpha1().HostRules(hr.Namespace).Create(context.TODO(), hr, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in creating hostrule for cluster %d: %v", cluster, err)
+	}
+	t.Cleanup(func() {
+		DeleteHostRule(t, cluster, newHr.Name, newHr.Namespace)
+	})
+	return newHr
+}
+
+func UpdateHostRule(t *testing.T, cluster int, hr *akov1alpha1.HostRule) *akov1alpha1.HostRule {
+	hrClient, err := hrcs.NewForConfig(cfgs[cluster])
+	if err != nil {
+		t.Fatalf("error in getting hostrule client for cluster %d: %v", cluster, err)
+	}
+
+	newHr, err := hrClient.AkoV1alpha1().HostRules(hr.Namespace).Update(context.TODO(), hr, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("error in updating hostrule for cluster %d: %v", cluster, err)
+	}
+	return newHr
+}
+
+func GetTestHostRule(t *testing.T, cluster int, name, ns string) *akov1alpha1.HostRule {
+	hrClient, err := hrcs.NewForConfig(cfgs[cluster])
+	if err != nil {
+		t.Fatalf("error in getting hostrule client for cluster %d: %v", cluster, err)
+	}
+
+	hr, err := hrClient.AkoV1alpha1().HostRules(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error in getting hostrule %s/%s: %v", ns, name, err)
+	}
+	return hr
+}
+
+func GetDefaultExpectedDomainNames(gsName string, hrObjList []*akov1alpha1.HostRule) []string {
+	aliasList := []string{}
+	for _, hr := range hrObjList {
+		aliasList = append(aliasList, hr.Spec.VirtualHost.Aliases...)
+	}
+	aliasSet := sets.NewString(aliasList...)
+	return aliasSet.Insert(gsName).List()
+}
+
+// Create host rules
+func TestHostRuleCreate(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hr-", hmRefs)
+	fqdn := ingObj.Spec.Rules[0].Host
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
+
+	// create a host rule for the ingress object's hostname, verify GS member
+	k8sHr := GetHostRuleWithAliases(hrNameK8s, ingCluster, ingObj.Namespace, fqdn,
+		gslbutils.HostRuleAccepted, nil)
+	CreateHostRule(t, K8s, k8sHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			GetDefaultExpectedDomainNames(fqdn, []*akov1alpha1.HostRule{k8sHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// create a host rule for the route object's hostname, verify GS members
+	ocHr := GetHostRuleWithAliases(hrNameOC, routeCluster, routeObj.Namespace, fqdn,
+		gslbutils.HostRuleAccepted, nil)
+	CreateHostRule(t, Oshift, ocHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			GetDefaultExpectedDomainNames(fqdn, []*akov1alpha1.HostRule{k8sHr, ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Create host rules and remove all aliases
+func TestHostRuleRemoveAliases(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hr-", hmRefs)
+	fqdn := ingObj.Spec.Rules[0].Host
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
+
+	// create a host rule for the ingress object's hostname, verify GS member
+	k8sHr := GetHostRuleWithAliases(hrNameK8s, ingCluster, ingObj.Namespace, fqdn,
+		gslbutils.HostRuleAccepted, nil)
+	CreateHostRule(t, K8s, k8sHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			GetDefaultExpectedDomainNames(fqdn, []*akov1alpha1.HostRule{k8sHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// create a host rule for the route object's hostname, verify GS members
+	ocHr := GetHostRuleWithAliases(hrNameOC, routeCluster, routeObj.Namespace, fqdn,
+		gslbutils.HostRuleAccepted, nil)
+	CreateHostRule(t, Oshift, ocHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			GetDefaultExpectedDomainNames(fqdn, []*akov1alpha1.HostRule{k8sHr, ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// update host rule for the ingress object's hostname, verify GS member
+	newK8sHr := GetTestHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	newK8sHr.Spec.VirtualHost.Aliases = []string{}
+	UpdateHostRule(t, K8s, newK8sHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			GetDefaultExpectedDomainNames(fqdn, []*akov1alpha1.HostRule{ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// update host rule for the route object's hostname, verify GS members
+	newOcHr := GetTestHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	newOcHr.Spec.VirtualHost.Aliases = []string{}
+	UpdateHostRule(t, Oshift, newOcHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			[]string{fqdn})
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Create, update aliases and delete host rules
+// Update cases
+// 1. appending new aliases
+// 2. replacing old aliases
+// 3. removing some of the old aliases
+func TestHostRuleCreateUpdateAliasesDelete(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hr-", hmRefs)
+	fqdn := ingObj.Spec.Rules[0].Host
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
+
+	// create a host rule for the ingress object's hostname, verify GS member
+	k8sHr := GetHostRuleWithAliases(hrNameK8s, ingCluster, ingObj.Namespace, fqdn,
+		gslbutils.HostRuleAccepted, nil)
+	CreateHostRule(t, K8s, k8sHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			GetDefaultExpectedDomainNames(fqdn, []*akov1alpha1.HostRule{k8sHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// create a host rule for the route object's hostname, verify GS members
+	ocHr := GetHostRuleWithAliases(hrNameOC, routeCluster, routeObj.Namespace, fqdn,
+		gslbutils.HostRuleAccepted, nil)
+	CreateHostRule(t, Oshift, ocHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			GetDefaultExpectedDomainNames(fqdn, []*akov1alpha1.HostRule{k8sHr, ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// update case 1 - Appending new aliases
+	newK8sHr := GetTestHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	newK8sHr.Spec.VirtualHost.Aliases = append(newK8sHr.Spec.VirtualHost.Aliases, []string{"newK8s_alias1.com", "newK8s_alias2.com"}...)
+	UpdateHostRule(t, K8s, newK8sHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			GetDefaultExpectedDomainNames(fqdn, []*akov1alpha1.HostRule{newK8sHr, ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// update case 2 - replacing old aliases
+	newOcHr := GetTestHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	newOcHr.Spec.VirtualHost.Aliases = []string{"newOc_alias1.com", "newOc_alias2.com"}
+	UpdateHostRule(t, Oshift, newOcHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			GetDefaultExpectedDomainNames(fqdn, []*akov1alpha1.HostRule{newK8sHr, newOcHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// update case 3 - removing some old aliases
+	newK8sHr = GetTestHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	// old aliases = {k8s_alias1.avi.com, k8s_alias2.avi.com, k8s_alias3.avi.com, newK8s_alias1.com, newK8s_alias2.com}
+	newK8sHr.Spec.VirtualHost.Aliases = []string{"k8s_alias3.avi.com", "newK8s_alias1.com", "newK8s_alias2.com"}
+	UpdateHostRule(t, K8s, newK8sHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			GetDefaultExpectedDomainNames(fqdn, []*akov1alpha1.HostRule{newK8sHr, newOcHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Delete HostRule
+	DeleteHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	DeleteHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			[]string{fqdn})
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Create, update aliases to have duplicate aliases in the same cluster
+func TestHostRuleCreateUpdateDuplicateAliasesInCluster(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hr-", hmRefs)
+	fqdn := ingObj.Spec.Rules[0].Host
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
+
+	// create a host rule for the ingress object's hostname, verify GS member
+	k8sHr := GetHostRuleWithAliases(hrNameK8s, ingCluster, ingObj.Namespace, fqdn,
+		gslbutils.HostRuleAccepted, nil)
+	CreateHostRule(t, K8s, k8sHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			GetDefaultExpectedDomainNames(fqdn, []*akov1alpha1.HostRule{k8sHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// create a host rule for the route object's hostname, verify GS members
+	ocHr := GetHostRuleWithAliases(hrNameOC, routeCluster, routeObj.Namespace, fqdn,
+		gslbutils.HostRuleAccepted, nil)
+	CreateHostRule(t, Oshift, ocHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			GetDefaultExpectedDomainNames(fqdn, []*akov1alpha1.HostRule{k8sHr, ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Update aliases for k8s hr
+	newK8sHr := GetTestHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	newK8sHr.Spec.VirtualHost.Aliases = []string{"dupK8s_alias.avi.com", "dupK8s_alias.avi.com"}
+	newK8sHr.Status.Status = gslbutils.HostRuleRejected
+	UpdateHostRule(t, K8s, newK8sHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			GetDefaultExpectedDomainNames(fqdn, []*akov1alpha1.HostRule{ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Update aliases for openshift hr
+	newOcHr := GetTestHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	newOcHr.Spec.VirtualHost.Aliases = []string{"dupOc_alias.avi.com", "dupOc_alias.avi.com"}
+	newOcHr.Status.Status = gslbutils.HostRuleRejected
+	UpdateHostRule(t, Oshift, newOcHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			[]string{fqdn})
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Create, update aliases to have duplicate aliases across clusters
+func TestHostRuleCreateUpdateDuplicateAliasesAcrossCluster(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hr-", hmRefs)
+	fqdn := ingObj.Spec.Rules[0].Host
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
+
+	// create a host rule for the ingress object's hostname, verify GS member
+	k8sHr := GetHostRuleWithAliases(hrNameK8s, ingCluster, ingObj.Namespace, fqdn,
+		gslbutils.HostRuleAccepted, nil)
+	CreateHostRule(t, K8s, k8sHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			GetDefaultExpectedDomainNames(fqdn, []*akov1alpha1.HostRule{k8sHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// create a host rule for the route object's hostname, verify GS members
+	ocHr := GetHostRuleWithAliases(hrNameOC, routeCluster, routeObj.Namespace, fqdn,
+		gslbutils.HostRuleAccepted, nil)
+	CreateHostRule(t, Oshift, ocHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			GetDefaultExpectedDomainNames(fqdn, []*akov1alpha1.HostRule{k8sHr, ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Update aliases for k8s hr
+	newK8sHr := GetTestHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	newK8sHr.Spec.VirtualHost.Aliases = append(newK8sHr.Spec.VirtualHost.Aliases, []string{"dup_alias.avi.com"}...)
+	UpdateHostRule(t, K8s, newK8sHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			GetDefaultExpectedDomainNames(fqdn, []*akov1alpha1.HostRule{newK8sHr, ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Update aliases for openshift hr
+	newOcHr := GetTestHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	newOcHr.Spec.VirtualHost.Aliases = append(newOcHr.Spec.VirtualHost.Aliases, []string{"dup_alias.avi.com"}...)
+	UpdateHostRule(t, Oshift, newOcHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			GetDefaultExpectedDomainNames(fqdn, []*akov1alpha1.HostRule{newK8sHr, newOcHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Create host rules with duplicate aliases in the same cluster and delete the HR
+func TestHostRuleCreateDeleteDuplicateAliasesInCluster(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hr-", hmRefs)
+	fqdn := ingObj.Spec.Rules[0].Host
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
+
+	// create a host rule for the ingress object's hostname, verify GS member
+	k8sHr := GetHostRuleWithAliases(hrNameK8s, ingCluster, ingObj.Namespace, fqdn,
+		gslbutils.HostRuleRejected, []string{"k8s_dup_alias.avi.com", "k8s_dup_alias.avi.com"})
+	CreateHostRule(t, K8s, k8sHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			[]string{fqdn})
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// create a host rule for the route object's hostname, verify GS members
+	ocHr := GetHostRuleWithAliases(hrNameOC, routeCluster, routeObj.Namespace, fqdn,
+		gslbutils.HostRuleRejected, []string{"oc_dup_alias.avi.com", "oc_dup_alias.avi.com"})
+	CreateHostRule(t, Oshift, ocHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			[]string{fqdn})
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Delete HostRule
+	DeleteHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	DeleteHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			[]string{fqdn})
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}
+
+// Create host rules with duplicate aliases across clusters and delete the HR
+func TestHostRuleCreateDeleteDuplicateAliasesAcrossCluster(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ingObj, routeObj := Initialize(t, "hr-", hmRefs)
+	fqdn := ingObj.Spec.Rules[0].Host
+
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
+
+	// create a host rule for the ingress object's hostname, verify GS member
+	k8sHr := GetHostRuleWithAliases(hrNameK8s, ingCluster, ingObj.Namespace, fqdn,
+		gslbutils.HostRuleAccepted, []string{"k8s_alias1.avi.com", "dup_alias.avi.com"})
+	CreateHostRule(t, K8s, k8sHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			GetDefaultExpectedDomainNames(fqdn, []*akov1alpha1.HostRule{k8sHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// create a host rule for the route object's hostname, verify GS members
+	ocHr := GetHostRuleWithAliases(hrNameOC, routeCluster, routeObj.Namespace, fqdn,
+		gslbutils.HostRuleAccepted, []string{"oshift_alias1.avi.com", "dup_alias.avi.com"})
+	CreateHostRule(t, Oshift, ocHr)
+
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			GetDefaultExpectedDomainNames(fqdn, []*akov1alpha1.HostRule{k8sHr, ocHr}))
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	// Delete HostRule
+	DeleteHostRule(t, K8s, k8sHr.Name, k8sHr.Namespace)
+	DeleteHostRule(t, Oshift, ocHr.Name, ocHr.Namespace)
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, fqdn, utils.ADMIN_NS, nil, nil, nil, nil, nil, hrIRPath, hrTls, nil,
+			[]string{fqdn})
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}

--- a/gslb/test/integration/third_party_vips/int_lib.go
+++ b/gslb/test/integration/third_party_vips/int_lib.go
@@ -709,8 +709,11 @@ func compareHmRefs(t *testing.T, expectedHmRefs, fetchedHmRefs []string) bool {
 	return true
 }
 
+// extraArgs can have the following additional parameters:
+// 1. hostrule aliases
+// the sequence must be followed to maintain the API.
 func verifyGSMembers(t *testing.T, expectedMembers []nodes.AviGSK8sObj, name string, tenant string,
-	hmRefs []string, hmTemplate *string, sitePersistenceRef *string, ttl *int, pa *gslbalphav1.PoolAlgorithmSettings, paths []string, tls bool, port *int32) bool {
+	hmRefs []string, hmTemplate *string, sitePersistenceRef *string, ttl *int, pa *gslbalphav1.PoolAlgorithmSettings, paths []string, tls bool, port *int32, extraArgs ...interface{}) bool {
 
 	gs := GetTestGSGraphFromName(t, name)
 	if gs == nil {
@@ -720,6 +723,19 @@ func verifyGSMembers(t *testing.T, expectedMembers []nodes.AviGSK8sObj, name str
 	members := gs.MemberObjs
 	if len(members) != len(expectedMembers) {
 		t.Logf("length of members don't match")
+		return false
+	}
+
+	if len(extraArgs) > 1 {
+		t.Fatalf("extraArgs for verifyGSMembers given unsupported number of parameters")
+	}
+	expectedDomainNames := []string{name}
+	if len(extraArgs) == 1 {
+		expectedDomainNames = extraArgs[0].([]string)
+	}
+
+	if !gslbutils.SetEqual(expectedDomainNames, gs.DomainNames) {
+		t.Logf("GS Domain names didn't match, expected: %v, got: %v", expectedDomainNames, gs.DomainNames)
 		return false
 	}
 


### PR DESCRIPTION
UTs for custom_fqdn mode hostrule variations.
Testcases added:
    1. TestHRCreate
    2. TestHRCreateUnsetIncludeAliases
    3. TestHRRemoveAliases
    4. TestHRCreateToggleIncludeAliases
    5. TestHRCreateUpdateGfdnDelete
    6. TestHRCreateUpdateGfdnDeleteUnsetIncludeAliases
    7. TestHRCreateUpdateAliasesDelete
    8. TestHRCreateUpdateAliasesDeleteUnsetIncludeAliases
    9. TestHRCreateUpdateDuplicateAliasesInCluster
    10. TestHRCreateUpdateDuplicateAliasesAcrossCluster
    11. TestHRCreateDeleteDuplicateAliasesInCluster
    12. TestHRCreateDeleteDuplicateAliasesAcrossCluster

UTs for non custom_fqdn mode hostrule variations.
    Testcases added:
    1. TestHostRuleCreate
    2. TestHostRuleRemoveAliases
    3. TestHostRuleCreateUpdateAliasesDelete
    4. TestHostRuleCreateUpdateDuplicateAliasesInCluster
    5. TestHostRuleCreateUpdateDuplicateAliasesAcrossCluster
    6. TestHostRuleCreateDeleteDuplicateAliasesInCluster
    7. TestHostRuleCreateDeleteDuplicateAliasesAcrossCluster