### PR TITLE
Fix for the upgrade issue in AMKO

### DIFF
--- a/service_discovery/modules/k8s_module/k8s.go
+++ b/service_discovery/modules/k8s_module/k8s.go
@@ -91,7 +91,9 @@ func InitServiceDiscoveryConfigAndInformers(cfg *rest.Config, stopCh <-chan stru
 	clusterConfigs, err := GetClusterInfo(k8sSDConfig)
 	if err != nil {
 		gslbutils.Errf("error in getting data from clusterset: %v", err)
-		log.Panic(err.Error())
+		// If the clusterset is not provided then don't progress and wait forever
+		<-stopCh
+		return
 	}
 	k8sSDConfig.SetClusterConfigs(clusterConfigs)
 


### PR DESCRIPTION
When the user upgrades the AMKO from 1.6.1 to 1.7.1, due to the addition of a new container `service-discovery` in the AMKO pod, the AMKO pod was going into a `CrashloopBackOff`. This fix has been added to make the service-discovery wait forever if the user has provided any clusterset configurations and the user has to restart the AMKO, once they
configure the clusterset.