### PR TITLE
Fix for the issue of AMKO pod does not respond periodically

### DIFF
--- a/gslb/gslbutils/gslbutils.go
+++ b/gslb/gslbutils/gslbutils.go
@@ -341,7 +341,7 @@ func SetGSLBConfigObj(gc *gslbalphav1.GSLBConfig) {
 	gcObj.configObj = gc
 }
 
-func UpdateAmkoUuidSLBConfig(gc *gslbalphav1.GSLBConfig, uuid string) error {
+func UpdateAmkoUuidGSLBConfig(gc *gslbalphav1.GSLBConfig, uuid string) error {
 	annotations := gc.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string)

--- a/gslb/ingestion/gslb.go
+++ b/gslb/ingestion/gslb.go
@@ -520,7 +520,7 @@ func GetUUIDFromGSLBConfig(gcObj *gslbalphav1.GSLBConfig) error {
 	}
 	uuidStr := uuidVal.String()
 	gslbutils.AMKOControlConfig().SetCreatedByField("amko-" + uuidStr)
-	if err := gslbutils.UpdateAmkoUuidSLBConfig(gcObj, uuidStr); err != nil {
+	if err := gslbutils.UpdateAmkoUuidGSLBConfig(gcObj, uuidStr); err != nil {
 		return fmt.Errorf("error in updating GSLBConfig object: %v", err)
 	}
 	return nil
@@ -976,7 +976,7 @@ func validateAndAddHmTemplateToCache(hmTemplate string, gdp bool, fullSync bool)
 		gslbutils.Debugf("health monitor template %s present in hm cache", hmTemplate)
 		return nil
 	}
-	hm, err := getHMFromName(hmTemplate, gdp)
+	hm, err := avictrl.GetHMFromName(hmTemplate, gdp)
 	if err != nil {
 		gslbutils.Errf("Health Monitor Template %s not found", hmTemplate)
 		return fmt.Errorf("health monitor template %s not found", hmTemplate)

--- a/gslb/ingestion/gslb_host_rule.go
+++ b/gslb/ingestion/gslb_host_rule.go
@@ -186,35 +186,6 @@ func isGslbPoolAlgorithmValid(algoSettings *gslbhralphav1.PoolAlgorithmSettings)
 	}
 }
 
-func getHMFromName(name string, gdp bool) (*models.HealthMonitor, error) {
-	aviClient := avictrl.SharedAviClients().AviClient[0]
-	uri := "api/healthmonitor?name=" + name
-
-	result, err := gslbutils.GetUriFromAvi(uri, aviClient, gdp)
-	if err != nil {
-		gslbutils.Errf("Error in getting uri %s from Avi: %v", uri, err)
-		return nil, err
-	}
-	if result.Count == 0 {
-		gslbutils.Errf("Health Monitor %s does not exist", name)
-		return nil, fmt.Errorf("health Monitor %s does not exist", name)
-	}
-	gslbutils.Logf("health monitor %s fetched from controller", name)
-	elems := make([]json.RawMessage, result.Count)
-	err = json.Unmarshal(result.Results, &elems)
-	if err != nil {
-		gslbutils.Errf("failed to unmarshal health monitor data for ref %s: %v", name, err)
-		return nil, err
-	}
-	hm := models.HealthMonitor{}
-	err = json.Unmarshal(elems[0], &hm)
-	if err != nil {
-		gslbutils.Errf("failed to unmarshal the first health monitor element: %v", err)
-		return nil, err
-	}
-	return &hm, nil
-}
-
 func isHealthMonitorRefPresentInCache(hmName string) bool {
 	aviHmCache := avictrl.GetAviHmCache()
 
@@ -232,7 +203,7 @@ func isHealthMonitorRefValid(refName string, gdp bool, fullSync bool) bool {
 		gslbutils.Debugf("health monitor %s present in hm cache", refName)
 		return true
 	}
-	hm, err := getHMFromName(refName, gdp)
+	hm, err := avictrl.GetHMFromName(refName, gdp)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
This PR adds the code changes to do a GET operation and update the hm cache when the controller throws an error `Health monitor with this Name and Tenant ref already exists` for hm creation.
