### PR TITLE
 [AV-148300] AMKO bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ Following steps have to be executed on all member clusters:
    $ helm search repo
 
    NAME     	CHART VERSION    	APP VERSION      	DESCRIPTION
-   ako/amko	1.7.1	            1.7.1	            A helm chart for Avi Multicluster Kubernetes Operator
+   amko/amko	1.7.1	            1.7.1	            A helm chart for Avi Multicluster Kubernetes Operator
 
    ```
 
 4. Use the `values.yaml` from this repository to provide values related to Avi configuration. To get the values.yaml for a release, run the following command
 
    ```
-   helm show values ako/amko --version 1.7.1 > values.yaml
+   helm show values amko/amko --version 1.7.1 > values.yaml
 
    ```
    Values and their corresponding index can be found [here](#parameters)
@@ -97,7 +97,7 @@ Following steps have to be executed on all member clusters:
 
 6. Install AMKO:
    ```
-   $ helm install  ako/amko  --generate-name --version 1.7.1 -f /path/to/values.yaml  --set configs.gsllbLeaderController=<leader_controller_ip> --namespace=avi-system
+   $ helm install  amko/amko  --generate-name --version 1.7.1 -f /path/to/values.yaml  --set configs.gsllbLeaderController=<leader_controller_ip> --namespace=avi-system
    ```
 7. Check the installation:
    ```
@@ -121,7 +121,7 @@ If a user needs to remove the already created GSLB services, one has to remove t
 kubectl delete gdp -n avi-system global-gdp
 ```
 
-Typically, an AKO instance could have been deployed in the `avi-system` namespace. But, if it is not, then the `avi-system` namespace can also be removed:
+Typically, an AMKO instance could have been deployed in the `avi-system` namespace. But, if it is not, then the `avi-system` namespace can also be removed:
 ```
 kubectl delete ns avi-system
 ```
@@ -135,7 +135,7 @@ Follow these steps if you are upgrading from an older AMKO release.
 Update the helm repo with the following command:
 
 ```
-helm repo update ako
+helm repo update amko
 ```
 
 *Step2*
@@ -143,7 +143,7 @@ helm repo update ako
 Helm does not upgrade the CRDs during a release upgrade. Before you upgrade a release, run the following command to download and upgrade the CRDs:
 
 ```
-helm template ako/amko --version 1.7.1 --include-crds --output-dir <output_dir>
+helm template amko/amko --version 1.7.1 --include-crds --output-dir <output_dir>
 ```
 
 This will save the helm files to an output directory which will contain the CRDs corresponding to the AMKO version.
@@ -167,9 +167,9 @@ amko-1598451370 avi-system	1       	2022-05-19 10:00:31.609195757 +0000 UTC	    
 Update the helm repo URL
 
 ```
-helm repo add --force-update ako https://projects.registry.vmware.com/chartrepo/ako
+helm repo add --force-update amko https://projects.registry.vmware.com/chartrepo/ako
 
-"ako" has been added to your repositories
+"amko" has been added to your repositories
 
 ```
 
@@ -178,14 +178,14 @@ helm repo add --force-update ako https://projects.registry.vmware.com/chartrepo/
 Get the values.yaml for the latest AMKO version
 
 ```
-helm show values ako/amko --version 1.7.1 > values.yaml
+helm show values amko/amko --version 1.7.1 > values.yaml
 
 ```
 
 Upgrade the helm chart
 
 ```
-helm upgrade amko-1598451370 ako/amko -f /path/to/values.yaml --version 1.7.1 --set configs.gslbLeaderController=<IP or Hostname> --set gslbLeaderCredentials.password=<username> --set gslbLeaderCredentials.username=<username> --namespace=avi-system
+helm upgrade amko-1598451370 amko/amko -f /path/to/values.yaml --version 1.7.1 --set configs.gslbLeaderController=<IP or Hostname> --set gslbLeaderCredentials.password=<username> --set gslbLeaderCredentials.username=<username> --namespace=avi-system
 
 ```
 

--- a/docs/crds/gslbconfig.md
+++ b/docs/crds/gslbconfig.md
@@ -34,3 +34,4 @@ spec:
 ### Notes
 * Only one `GSLBConfig` object is allowed.
 * If using `helm install`, a `GSLBConfig` object is created by picking up values from the `values.yaml` file.
+* During `helm delete`, the `GSLBConfig` that holds the UUID of the current instance is deleted. Hence a cleanup of stale GSLB services, if any, is required at the controller before re-installing AMKO.

--- a/gslb/k8sobjects/ingress_object.go
+++ b/gslb/k8sobjects/ingress_object.go
@@ -130,7 +130,7 @@ func GetIngressHostMeta(ingress *networkingv1.Ingress, cname string) []IngressHo
 		// Note that the ingress key will still be published to graph layer, but the key
 		// won't be processed, this is just to maintain the ingress information as part
 		// of in-memory map.
-		gslbutils.Errf("ns: %s, ingress: %s, msg: skipping ingress because of error: %v",
+		gslbutils.Logf("ns: %s, ingress: %s, msg: skipping ingress because of error: %v",
 			ingress.Namespace, ingress.Name, err)
 	}
 	if (controllerUUID == "" || len(vsUUIDs) == 0) && !syncVIPsOnly {

--- a/gslb/k8sobjects/multicluster_ingress_objects.go
+++ b/gslb/k8sobjects/multicluster_ingress_objects.go
@@ -65,7 +65,7 @@ func GetHostMetaForMultiClusterIngress(mci *akov1alpha1.MultiClusterIngress, cna
 		// Note that the ingress key will still be published to graph layer, but the key
 		// won't be processed, this is just to maintain the ingress information as part
 		// of in-memory map.
-		gslbutils.Errf("ns: %s, ingress: %s, msg: skipping ingress because of error: %v",
+		gslbutils.Logf("ns: %s, ingress: %s, msg: skipping ingress because of error: %v",
 			mci.Namespace, mci.Name, err)
 	}
 	if (controllerUUID == "" || len(vsUUIDs) == 0) && !syncVIPsOnly {

--- a/gslb/nodes/avi_model_nodes.go
+++ b/gslb/nodes/avi_model_nodes.go
@@ -436,10 +436,10 @@ func (v *AviGSObjectGraph) buildAndAttachHealthMonitorsFromObj(obj AviGSK8sObj, 
 	tls := obj.TLS
 	if tls {
 		v.Hm.HMProtocol = gslbutils.SystemGslbHealthMonitorHTTPS
-		v.Hm.Port = gslbutils.DefaultHTTPHealthMonitorPort
+		v.Hm.Port = gslbutils.DefaultHTTPSHealthMonitorPort
 	} else {
 		v.Hm.HMProtocol = gslbutils.SystemGslbHealthMonitorHTTP
-		v.Hm.Port = gslbutils.DefaultHTTPSHealthMonitorPort
+		v.Hm.Port = gslbutils.DefaultHTTPHealthMonitorPort
 	}
 }
 
@@ -466,10 +466,10 @@ func (v *AviGSObjectGraph) buildAndAttachHealthMonitors(metaObj k8sobjects.MetaO
 	}
 	if tls {
 		v.Hm.HMProtocol = gslbutils.SystemGslbHealthMonitorHTTPS
-		v.Hm.Port = gslbutils.DefaultHTTPHealthMonitorPort
+		v.Hm.Port = gslbutils.DefaultHTTPSHealthMonitorPort
 	} else {
 		v.Hm.HMProtocol = gslbutils.SystemGslbHealthMonitorHTTP
-		v.Hm.Port = gslbutils.DefaultHTTPSHealthMonitorPort
+		v.Hm.Port = gslbutils.DefaultHTTPHealthMonitorPort
 	}
 }
 


### PR DESCRIPTION
This PR adds the following changes:
1. Reduces the log level of the log from error to info which is logged 
    when VS and controller UUID is not present in the ingress and
     multi-cluster ingress objects.
2. Documents the AMKO's UUID behavior during re-installation.
3. Corrected the health monitor's port filled for HTTP/HTTPS health monitors.

Fixes the issue AV-148300