### PR TITLE
AV-157643: Fixes deletion of health monitors specified in healthMonitorRefs from the controller

### DIFF
--- a/gslb/rest/dq_nodes.go
+++ b/gslb/rest/dq_nodes.go
@@ -213,7 +213,7 @@ func (restOp *RestOperations) getHmPathDiff(aviGSGraph *nodes.AviGSObjectGraph, 
 	existingHMObjs := GetHMCacheObjFromGSCache(gsCacheObj)
 	for _, hmObj := range existingHMObjs {
 		hmName := hmObj.Name
-		if _, exists := newHms[hmName]; !exists {
+		if _, exists := newHms[hmName]; !exists && aviGSGraph.IsHmTypeCustom(hmName) {
 			toBeDeleted = append(toBeDeleted, hmName)
 		}
 	}


### PR DESCRIPTION
This PR contains the fix for AMKO deleting the health monitor reference specified in healthMonitorRefs of GDP/GSLBHostrule from the controller resulting in an error while creating any new GS services.
FT PR: https://github.com/avinetworks/avi-dev/pull/98151
