### PR TITLE
fix for AV-168552

### DIFF
--- a/gslb/ingestion/gslb_host_rule.go
+++ b/gslb/ingestion/gslb_host_rule.go
@@ -252,6 +252,9 @@ func isGSLBDownResponseValid(responseType string, fallbackIP string) error {
 		if fallbackIP == "" {
 			return fmt.Errorf("Fallback IP is required for %s", responseType)
 		}
+		if net.ParseIP(fallbackIP) == nil {
+			return fmt.Errorf("Fallback IP %s is not valid", fallbackIP)
+		}
 	default:
 		if fallbackIP != "" {
 			return fmt.Errorf("Fallback IP is not allowed for %s", responseType)

--- a/gslb/test/ingestion/gslbhostrule_test.go
+++ b/gslb/test/ingestion/gslbhostrule_test.go
@@ -216,4 +216,16 @@ func TestGSLBHostRuleInvalidDownResponse(t *testing.T) {
 	t.Logf("Verifying GSLBHostRule")
 	g.Expect(err).NotTo(gomega.BeNil())
 	t.Logf("Verified GSLBHostRule")
+
+	// GSLBHostRule with down response of type GSLB_SERVICE_DOWN_RESPONSE_FALLBACK_IP and with an invalid IP address as fallbackIP
+	gslbhrObj.Spec.DownResponse = &gslbalphav1.DownResponse{
+		Type:       gslbalphav1.GSLBServiceDownResponseFallbackIP,
+		FallbackIP: "INVALID",
+	}
+	t.Logf("Adding GSLBHostRule with down response of type GSLB_SERVICE_DOWN_RESPONSE_FALLBACK_IP and with an invalid IP address as fallbackIP")
+	err = gslbingestion.ValidateGSLBHostRule(gslbhrObj, false)
+	t.Logf("Verifying GSLBHostRule")
+	g.Expect(err).NotTo(gomega.BeNil())
+	g.Expect(err.Error()).Should(gomega.Equal("Fallback IP INVALID is not valid"))
+	t.Logf("Verified GSLBHostRule")
 }

--- a/gslb/test/ingestion/gslbhostrule_test.go
+++ b/gslb/test/ingestion/gslbhostrule_test.go
@@ -165,3 +165,55 @@ func TestGSLBHostRuleBothHmRefAndHmTemplate(t *testing.T) {
 	g.Expect(err).NotTo(gomega.BeNil())
 	t.Logf("Verified GSLBHostRule")
 }
+
+func TestGSLBHostRuleValidDownResponse(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	gslbhrObj := getTestGSLBHRObject(gslbhrTestObjName, gslbhrTestNamespace, gslbhrTestFqdn)
+
+	// GSLBHostRule with down response of type GSLB_SERVICE_DOWN_RESPONSE_EMPTY
+	gslbhrObj.Spec.DownResponse = &gslbalphav1.DownResponse{
+		Type: gslbalphav1.GSLBServiceDownResponseEmpty,
+	}
+	t.Logf("Adding GSLBHostRule with down response of type GSLB_SERVICE_DOWN_RESPONSE_EMPTY")
+	err := gslbingestion.ValidateGSLBHostRule(gslbhrObj, false)
+	t.Logf("Verifying GSLBHostRule")
+	g.Expect(err).To(gomega.BeNil())
+	t.Logf("Verified GSLBHostRule")
+
+	// GSLBHostRule with down response of type GSLB_SERVICE_DOWN_RESPONSE_FALLBACK_IP and with a fallbackIP
+	gslbhrObj.Spec.DownResponse = &gslbalphav1.DownResponse{
+		Type:       gslbalphav1.GSLBServiceDownResponseFallbackIP,
+		FallbackIP: "10.10.1.1",
+	}
+	t.Logf("Adding GSLBHostRule with down response of type GSLB_SERVICE_DOWN_RESPONSE_FALLBACK_IP and with a fallbackIP")
+	err = gslbingestion.ValidateGSLBHostRule(gslbhrObj, false)
+	t.Logf("Verifying GSLBHostRule")
+	g.Expect(err).To(gomega.BeNil())
+	t.Logf("Verified GSLBHostRule")
+}
+
+func TestGSLBHostRuleInvalidDownResponse(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	// GSLBHostRule with down response of type GSLB_SERVICE_DOWN_RESPONSE_FALLBACK_IP and empty fallbackIP.
+	gslbhrObj := getTestGSLBHRObject(gslbhrTestObjName, gslbhrTestNamespace, gslbhrTestFqdn)
+	gslbhrObj.Spec.DownResponse = &gslbalphav1.DownResponse{
+		Type: gslbalphav1.GSLBServiceDownResponseFallbackIP,
+	}
+	t.Logf("Adding GSLBHostRule with down response of type GSLB_SERVICE_DOWN_RESPONSE_FALLBACK_IP and empty fallbackIP")
+	err := gslbingestion.ValidateGSLBHostRule(gslbhrObj, false)
+	t.Logf("Verifying GSLBHostRule")
+	g.Expect(err).NotTo(gomega.BeNil())
+	t.Logf("Verified GSLBHostRule")
+
+	// GSLBHostRule with down response of type GSLB_SERVICE_DOWN_RESPONSE_ALL_RECORDS and with a fallbackIP
+	gslbhrObj.Spec.DownResponse = &gslbalphav1.DownResponse{
+		Type:       gslbalphav1.GSLBServiceDownResponseAllRecords,
+		FallbackIP: "10.10.1.2",
+	}
+	t.Logf("Adding GSLBHostRule with down response of type GSLB_SERVICE_DOWN_RESPONSE_ALL_RECORDS and with a fallbackIP")
+	err = gslbingestion.ValidateGSLBHostRule(gslbhrObj, false)
+	t.Logf("Verifying GSLBHostRule")
+	g.Expect(err).NotTo(gomega.BeNil())
+	t.Logf("Verified GSLBHostRule")
+}


### PR DESCRIPTION
This PR contains the following changes:
1. Adds validation to accept only IP address to fix the bug AV-168552
2. UTs to test the `downResponse` in GSLB service.