### PR TITLE
UTs to test the fix for AV-168552

### DIFF
--- a/federator/controllers/suite_test.go
+++ b/federator/controllers/suite_test.go
@@ -259,6 +259,18 @@ var _ = Describe("Federation Operation", func() {
 			TestGCGDPExist(k8sClient2)
 		})
 
+		It("should federate UUID in GC to cluster2", func() {
+			Eventually(func() string {
+				var obj gslbalphav1.GSLBConfig
+				Expect(k8sClient2.Get(context.TODO(),
+					types.NamespacedName{
+						Name:      gcObj.Name,
+						Namespace: gcObj.Namespace},
+					&obj)).Should(Succeed())
+				return obj.Annotations["amko.vmware.com/amko-uuid"]
+			}, 5*time.Second, 1*time.Second).Should(Equal("3e328a5c-a717-11ed-a422-0a580a80025b"))
+		})
+
 		It("should federate GC updates to cluster2", func() {
 			By("updating the GC object on cluster1")
 			ctx := context.Background()

--- a/federator/controllers/test_utils.go
+++ b/federator/controllers/test_utils.go
@@ -223,6 +223,9 @@ func getTestGCObj() gslbalphav1.GSLBConfig {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      TestGCName,
 			Namespace: AviSystemNS,
+			Annotations: map[string]string{
+				"amko.vmware.com/amko-uuid": "3e328a5c-a717-11ed-a422-0a580a80025b",
+			},
 		},
 		Spec: gslbalphav1.GSLBConfigSpec{
 			GSLBLeader: gslbalphav1.GSLBLeader{


### PR DESCRIPTION
This PR contains the UT changes to test the changes added to fix the issue AV-168552.

Results:
```
Ran 42 of 42 Specs in 40.058 seconds
SUCCESS! -- 42 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestAPIs (40.09s)
PASS
ok  	github.com/vmware/global-load-balancing-services-for-kubernetes/federator/controllers
```