### PR TITLE
AV-181807: Set the client version to 22.1.2 for controller versions above 22.1.2

### DIFF
--- a/gslb/gslbutils/constants.go
+++ b/gslb/gslbutils/constants.go
@@ -124,4 +124,7 @@ const (
 
 	// Default secret constants
 	DefaultSecretEnabled = "ako.vmware.com/enable-tls"
+
+	// Controller version constants
+	CONTROLLER_VERSION_22_1_2 = "22.1.2"
 )

--- a/gslb/ingestion/gslb.go
+++ b/gslb/ingestion/gslb.go
@@ -492,6 +492,14 @@ func parseControllerDetails(gc *gslbalphav1.GSLBConfig) error {
 	}
 	ctrlUsername := secretObj.Data["username"]
 	ctrlPassword := secretObj.Data["password"]
+
+	// Setting the client version as 22.1.2 as a work around for the GSLB service creation failure
+	// in 22.1.3 due to introduction of mandatory PKI profile.
+	// TODO: Change this logic and incorporate the PKI profile in the future releases.
+	if leaderVersion > gslbutils.CONTROLLER_VERSION_22_1_2 {
+		leaderVersion = gslbutils.CONTROLLER_VERSION_22_1_2
+	}
+
 	gslbutils.NewAviControllerConfig(string(ctrlUsername), string(ctrlPassword), leaderIP, leaderVersion)
 
 	return nil


### PR DESCRIPTION
This PR adds the changes to cap the version to 22.1.2 when the controller version is above 22.1.2.

**Scenarios tested:**
Manually tested the scenario by setting the `controllerVersion` in `GSLBconfig` as `22.1.4` and checked the version coming in the logs.

```
2023-06-16T09:33:30.530Z    ^[[35mDEBUG^[[0m    rest/dq_nodes.go:1137   key: admin/green-secure-app.avi.internal, gsMeta: {green-secure-app.avi.internal admin [green-secure-app.avi.internal] [{cluster1-admin   ROUTE secure-app green 10.10.7.23 1 10 false  0  true [/foo]   false}] 2530721847 5 { HEALTH_MONITOR_HTTPS 443 PathHM [{amko--66f4133eeae3c76cf1c20c8cde0c6fa3c162ab8b https /foo}]} [] <nil> <*>gap-1 <nil> <*   >{GSLB_ALGORITHM_ROUND_ROBIN <nil> <nil>} <nil> <*>{{0 0} 0 0 0 0}}, msg: GS rest operation {"Path":"/api/gslbservice/","Method":"POST","Obj":{"application_persistence_profile_ref":"/api/                       applicationpersistenceprofile?name=gap-1","controller_health_status_enabled":true,"created_by":"amko-12fd1d76-0c28-11ee-95a5-0a580a83013f","description":"ROUTE/cluster1-admin/green/secure-app","domain_names":  ["green-secure-app.avi.internal"],"enabled":true,"groups":[{"algorithm":"GSLB_ALGORITHM_ROUND_ROBIN","enabled":true,"members":[{"enabled":true,"ip":{"addr":"10.10.7.23","type":"V4"},"ratio":1,"vs_uuid":""}],   "min_health_monitors_up":2,"name":"amko-gs-group-10","priority":10}],"health_monitor_refs":["/api/healthmonitor?name=amko--66f4133eeae3c76cf1c20c8cde0c6fa3c162ab8b"],"health_monitor_scope":                     "GSLB_SERVICE_HEALTH_MONITOR_ALL_MEMBERS","is_federated":true,"min_members":0,"name":"green-secure-app.avi.internal","pool_algorithm":"GSLB_SERVICE_ALGORITHM_PRIORITY","resolve_cname":false,                    "site_persistence_enabled":true,"tenant_ref":"https:///api/tenant/admin","use_edns_client_subnet":true,"wildcard_match":false},"Tenant":"admin","PatchOp":"","Response":null,"Err":null,"Message":"","Model":     "GSLBService","Version":"22.1.2","ObjName":"green-secure-app.avi.internal"}
```