### PR TITLE
AV-181807: Adds a known issue to 1.9.1 changelogs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     name: Golangci-lint
     strategy:
       matrix:
-        platform: [ ubuntu-18.04 ]
+        platform: [ ubuntu-20.04 ]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Set up Go 1.18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,3 +86,6 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Bugs fixed:
   - Fixed an issue of UUID not being federated across member clusters.
+
+### Known Issues:
+  - AMKO fails to create GSLB services with site persistence enabled for controller versions above 22.1.2.


### PR DESCRIPTION
This PR adds the known issue of GSLB service with site persistence failure in controllers above 22.1.2 to the changelogs.