### PR TITLE
AV-203582 add amkouuid in healthmonitor name for passthrough route

### DIFF
--- a/gslb/gslbutils/control_config.go
+++ b/gslb/gslbutils/control_config.go
@@ -115,3 +115,7 @@ func (c *amkoControlConfig) SetCreatedByField(val string) {
 func (c *amkoControlConfig) CreatedByField() string {
 	return c.amkoCreatedByField
 }
+
+func (c *amkoControlConfig) GetAMKOUUID() string {
+	return c.amkoCreatedByField[4:]
+}

--- a/gslb/nodes/avi_model_nodes.go
+++ b/gslb/nodes/avi_model_nodes.go
@@ -155,7 +155,7 @@ func (hm HealthMonitor) GetHMDescription(gsName string, template *string) []stri
 	descPrefix := CreatedByAMKO + ", gsname: " + gsName
 	desc = append(desc, descPrefix)
 	if hm.Type == NonPathHM {
-		if hm.Name == gslbutils.SystemGslbHealthMonitorPassthrough {
+		if hm.Name == gslbutils.SystemGslbHealthMonitorPassthrough+gslbutils.AMKOControlConfig().GetAMKOUUID() {
 			return []string{CreatedByAMKO}
 		}
 		return desc
@@ -367,7 +367,7 @@ func (v *AviGSObjectGraph) BuildNonPathHmName(gsName string) string {
 func (v *AviGSObjectGraph) buildNonPathHealthMonitorFromObj(port int32, isPassthrough bool, protocol, key string) {
 	hmName := ""
 	if isPassthrough {
-		hmName = gslbutils.SystemGslbHealthMonitorPassthrough
+		hmName = gslbutils.SystemGslbHealthMonitorPassthrough + gslbutils.AMKOControlConfig().GetAMKOUUID()
 	} else {
 		hmName = v.BuildNonPathHmName(v.Name)
 	}
@@ -557,7 +557,7 @@ func (v *AviGSObjectGraph) checkAndUpdateNonPathHealthMonitor(objType string, is
 
 	hmName := ""
 	if isPassthrough {
-		hmName = gslbutils.SystemGslbHealthMonitorPassthrough
+		hmName = gslbutils.SystemGslbHealthMonitorPassthrough + gslbutils.AMKOControlConfig().GetAMKOUUID()
 	} else {
 		hmName = v.BuildNonPathHmName(v.Name)
 	}

--- a/gslb/rest/dq_nodes.go
+++ b/gslb/rest/dq_nodes.go
@@ -1215,7 +1215,7 @@ func (restOp *RestOperations) deleteHmIfRequired(gsName, tenant, key string, gsC
 	}
 
 	// passthrough health monitor is shared across all passthrough GSs and hence, won't be deleted
-	if hmName == gslbutils.SystemGslbHealthMonitorPassthrough {
+	if hmName == gslbutils.SystemGslbHealthMonitorPassthrough+gslbutils.AMKOControlConfig().GetAMKOUUID() {
 		gslbutils.Debugf("key: %s, hmName: %s, msg: won't delete the passthrough health monitor", key, hmName)
 		return nil
 	}


### PR DESCRIPTION
Tested on open shift setup by creating a passthrough route.  Health monitor amko--passthrough-hm-tcp was replaced by hm with name amko--passthrough-hm-tcp-6152369d-f751-11ee-999e-12c08ce663db