### PR TITLE
Add value for configuring optional annotations for the gslb-avi-scret

### DIFF
--- a/helm/amko/templates/secret.yaml
+++ b/helm/amko/templates/secret.yaml
@@ -3,6 +3,10 @@ kind: Secret
 metadata:
   name: "gslb-avi-secret"
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.secret.annotations }}
+  annotations:
+  {{ toYaml . | indent 4 }}
+  {{- end }}
 type: Opaque
 data:
   username: {{ .Values.gslbLeaderCredentials.username | b64enc }}

--- a/helm/amko/values.yaml
+++ b/helm/amko/values.yaml
@@ -168,3 +168,6 @@ mountPath: "/log"
 logFile: "amko.log"
 
 federatorLogFile: "amko-federator.log"
+
+secret:
+  annotations: {}


### PR DESCRIPTION
This PR adds the possibility to configure annotations on the gslb-avi-secret.