### PR TITLE
AV-220286  set tenant from gslbconfig if namespacetenant is empty

### DIFF
--- a/gslb/gslbutils/gslbutils.go
+++ b/gslb/gslbutils/gslbutils.go
@@ -491,6 +491,15 @@ func GetTenantInNamespaceAnnotation(namespace, cname string) string {
 	return tenant
 }
 
+func CheckTenant(namespace, cname, tenant string) bool {
+	namespaceTenant := GetTenantInNamespaceAnnotation(namespace, cname)
+	if namespaceTenant != "" && tenant != namespaceTenant {
+		Logf("cluster: %s, nstenant: %s, tenant: %s, msg: %s\n", cname, namespaceTenant, tenant, "rejected object because object tenant is not same as namespace tenant")
+		return false
+	}
+	return true
+}
+
 var allClusterContexts []string
 
 func AddClusterContext(cc string) {

--- a/gslb/k8sobjects/route_object.go
+++ b/gslb/k8sobjects/route_object.go
@@ -56,6 +56,12 @@ func GetRouteMeta(route *routev1.Route, cname string) RouteMeta {
 		gslbutils.Logf("cluster: %s, ns: %s, route: %s, msg: parsing Controller annotations", cname, route.Namespace, route.Name)
 		vsUUIDs, controllerUUID, tenant, err = parseVSAndControllerAnnotations(route.Annotations)
 	}
+	namespaceTenant := gslbutils.GetTenantInNamespaceAnnotation(route.Namespace, cname)
+	if namespaceTenant == "" {
+		tenant = gslbutils.GetTenant()
+		gslbutils.Debugf("cluster: %s, ns: %s, ingress: %s, tenant:%s, namespaceTenant %s ",
+			cname, route.Namespace, route.Name, tenant, namespaceTenant)
+	}
 	if err != nil && !syncVIPsOnly {
 		gslbutils.Logf("cluster: %s, ns: %s, route: %s, msg: skipping route because of error: %v",
 			cname, route.Namespace, route.Name, err)

--- a/gslb/k8sobjects/service_object.go
+++ b/gslb/k8sobjects/service_object.go
@@ -83,6 +83,10 @@ func GetSvcMeta(svc *corev1.Service, cname string) (SvcMeta, bool) {
 			cname, svc.Namespace, svc.Name, err)
 	}
 	vsUUIDs, controllerUUID, tenant, err := parseVSAndControllerAnnotations(svc.Annotations)
+	namespaceTenant := gslbutils.GetTenantInNamespaceAnnotation(svc.Namespace, cname)
+	if namespaceTenant == "" {
+		tenant = gslbutils.GetTenant()
+	}
 	if err != nil && !syncVIPsOnly {
 		gslbutils.Logf("cluster: %s, ns: %s, service: %s, msg: skipping service because of error in parsing VS and Controller annotations: %v",
 			cname, svc.Namespace, svc.Name, err)

--- a/gslb/test/ingestion/routes_test.go
+++ b/gslb/test/ingestion/routes_test.go
@@ -73,7 +73,7 @@ func buildRouteObj(name, ns, svc, cname, host, ip string, withStatus bool) *rout
 	annot := map[string]string{
 		gslbutils.VSAnnotation:         "",
 		gslbutils.ControllerAnnotation: "",
-		gslbutils.TenantAnnotation:     "admin",
+		gslbutils.TenantAnnotation:     tenant,
 	}
 	routeObj.Annotations = annot
 	return routeObj
@@ -158,13 +158,13 @@ func TestBasicRouteCD(t *testing.T) {
 
 	t.Log("adding and testing route")
 	ocAddRoute(t, fooOshiftClient, routeName, ns, TestSvc, cname, host, ipAddr)
-	buildRouteKeyAndVerify(t, false, "ADD", cname, ns, routeName, "admin")
+	buildRouteKeyAndVerify(t, false, "ADD", cname, ns, routeName, tenant)
 	// verify the presence of the route in the accepted store
 	verifyInRouteStore(g, acceptedRouteStore, true, routeName, ns, cname, host, ipAddr)
 
 	// delete and verify
 	ocDeleteRoute(t, fooOshiftClient, routeName, ns)
-	buildRouteKeyAndVerify(t, false, "DELETE", cname, ns, routeName, "admin")
+	buildRouteKeyAndVerify(t, false, "DELETE", cname, ns, routeName, tenant)
 
 	DeleteTestGDPObj(gdp)
 }
@@ -182,7 +182,7 @@ func TestBasicRouteCUD(t *testing.T) {
 
 	t.Log("adding and testing route")
 	route := ocAddRoute(t, fooOshiftClient, routeName, ns, TestSvc, cname, host, ipAddr)
-	buildRouteKeyAndVerify(t, false, "ADD", cname, ns, routeName, "admin")
+	buildRouteKeyAndVerify(t, false, "ADD", cname, ns, routeName, tenant)
 	// verify the presence of the route in the accepted store
 	verifyInRouteStore(g, acceptedRouteStore, true, routeName, ns, cname, host, ipAddr)
 
@@ -192,11 +192,11 @@ func TestBasicRouteCUD(t *testing.T) {
 
 	t.Log("updating route")
 	ocUpdateRoute(t, fooOshiftClient, ns, cname, route)
-	buildRouteKeyAndVerify(t, false, "UPDATE", cname, ns, routeName, "admin")
+	buildRouteKeyAndVerify(t, false, "UPDATE", cname, ns, routeName, tenant)
 
 	// delete and verify
 	ocDeleteRoute(t, fooOshiftClient, routeName, ns)
-	buildRouteKeyAndVerify(t, false, "DELETE", cname, ns, routeName, "admin")
+	buildRouteKeyAndVerify(t, false, "DELETE", cname, ns, routeName, tenant)
 
 	DeleteTestGDPObj(gdp)
 }
@@ -214,26 +214,26 @@ func TestBasicRouteLabelChange(t *testing.T) {
 	// add and test routes
 	t.Log("adding and testing routes")
 	routeObj := ocAddRoute(t, fooOshiftClient, routeName, ns, TestSvc, cname, host, ipAddr)
-	buildRouteKeyAndVerify(t, false, "ADD", cname, ns, routeName, "admin")
+	buildRouteKeyAndVerify(t, false, "ADD", cname, ns, routeName, tenant)
 
 	routeObj.Labels["key"] = "value1"
 	ocUpdateRoute(t, fooOshiftClient, ns, cname, routeObj)
 
 	// the key should be for delete, as we have amended the label on the route
-	buildRouteKeyAndVerify(t, false, "DELETE", cname, ns, routeName, "admin")
+	buildRouteKeyAndVerify(t, false, "DELETE", cname, ns, routeName, tenant)
 	verifyInRouteStore(g, acceptedRouteStore, false, routeName, ns, cname, host, ipAddr)
 	verifyInRouteStore(g, rejectedRouteStore, true, routeName, ns, cname, host, ipAddr)
 
 	// update it again, and allow it to pass
 	routeObj.Labels["key"] = "value"
 	ocUpdateRoute(t, fooOshiftClient, ns, cname, routeObj)
-	buildRouteKeyAndVerify(t, false, "ADD", cname, ns, routeName, "admin")
+	buildRouteKeyAndVerify(t, false, "ADD", cname, ns, routeName, tenant)
 	verifyInRouteStore(g, rejectedRouteStore, false, routeName, ns, cname, host, ipAddr)
 	verifyInRouteStore(g, acceptedRouteStore, true, routeName, ns, cname, host, ipAddr)
 
 	// delete the route and verify
 	ocDeleteRoute(t, fooOshiftClient, routeName, ns)
-	buildRouteKeyAndVerify(t, false, "DELETE", cname, ns, routeName, "admin")
+	buildRouteKeyAndVerify(t, false, "DELETE", cname, ns, routeName, tenant)
 	DeleteTestGDPObj(gdp)
 }
 
@@ -249,13 +249,13 @@ func TestEmptyStatusRoute(t *testing.T) {
 	// Add and test ingresses
 	t.Log("adding and testing route")
 	ocAddRouteWithoutStatus(t, fooOshiftClient, routeName, ns, TestSvc, cname, host)
-	buildRouteKeyAndVerify(t, true, "ADD", cname, ns, routeName, "admin")
+	buildRouteKeyAndVerify(t, true, "ADD", cname, ns, routeName, tenant)
 	// Verify the presence of the object in the accepted store
 	verifyInRouteStore(g, acceptedRouteStore, false, routeName, ns, cname, "", "")
 
 	// delete and verify
 	ocDeleteRoute(t, fooOshiftClient, routeName, ns)
-	buildRouteKeyAndVerify(t, true, "DELETE", cname, ns, routeName, "admin")
+	buildRouteKeyAndVerify(t, true, "DELETE", cname, ns, routeName, tenant)
 	// should be deleted from the accepted store
 	verifyInRouteStore(g, acceptedRouteStore, false, routeName, ns, cname, "", "")
 	DeleteTestGDPObj(gdp)
@@ -275,19 +275,19 @@ func TestStatusChangeToEmptyRoute(t *testing.T) {
 	// add and test routes
 	t.Log("adding and testing routes")
 	routeObj := ocAddRoute(t, fooOshiftClient, routeName, ns, TestSvc, cname, host, ipAddr)
-	buildRouteKeyAndVerify(t, false, "ADD", cname, ns, routeName, "admin")
+	buildRouteKeyAndVerify(t, false, "ADD", cname, ns, routeName, tenant)
 	// verify the object in the accepted store as well
 	verifyInRouteStore(g, acceptedRouteStore, true, routeName, ns, cname, host, ipAddr)
 
 	routeObj.Status.Ingress[0].Conditions[0].Message = ""
 	routeObj.Status.Ingress[0].Host = ""
 	ocUpdateRoute(t, fooOshiftClient, ns, cname, routeObj)
-	buildRouteKeyAndVerify(t, false, "DELETE", cname, ns, routeName, "admin")
+	buildRouteKeyAndVerify(t, false, "DELETE", cname, ns, routeName, tenant)
 	verifyInRouteStore(g, acceptedRouteStore, false, routeName, ns, cname, host, ipAddr)
 
 	// delete and verify
 	ocDeleteRoute(t, fooOshiftClient, routeName, ns)
-	buildRouteKeyAndVerify(t, true, "DELETE", cname, ns, routeName, "admin")
+	buildRouteKeyAndVerify(t, true, "DELETE", cname, ns, routeName, tenant)
 	// should be deleted from the accepted store
 	verifyInRouteStore(g, acceptedRouteStore, false, routeName, ns, cname, host, ipAddr)
 	DeleteTestGDPObj(gdp)
@@ -307,7 +307,7 @@ func TestStatusChangeFromEmptyRoute(t *testing.T) {
 	// add and test routes
 	t.Log("adding and testing routes")
 	routeObj := ocAddRouteWithoutStatus(t, fooOshiftClient, routeName, ns, TestSvc, cname, host)
-	buildRouteKeyAndVerify(t, true, "ADD", cname, ns, routeName, "admin")
+	buildRouteKeyAndVerify(t, true, "ADD", cname, ns, routeName, tenant)
 
 	// verify the presence of the object in the accepted store
 	verifyInRouteStore(g, acceptedRouteStore, false, routeName, ns, cname, host, ipAddr)
@@ -323,12 +323,12 @@ func TestStatusChangeFromEmptyRoute(t *testing.T) {
 	}
 	t.Log("updating route to have non-empty status field")
 	ocUpdateRoute(t, fooOshiftClient, ns, cname, routeObj)
-	buildRouteKeyAndVerify(t, false, "ADD", cname, ns, routeName, "admin")
+	buildRouteKeyAndVerify(t, false, "ADD", cname, ns, routeName, tenant)
 	verifyInRouteStore(g, acceptedRouteStore, true, routeName, ns, cname, host, ipAddr)
 
 	// delete and verify
 	ocDeleteRoute(t, fooOshiftClient, routeName, ns)
-	buildRouteKeyAndVerify(t, false, "DELETE", cname, ns, routeName, "admin")
+	buildRouteKeyAndVerify(t, false, "DELETE", cname, ns, routeName, tenant)
 	// should be deleted from the accepted store
 	verifyInRouteStore(g, acceptedRouteStore, false, routeName, ns, cname, host, ipAddr)
 	DeleteTestGDPObj(gdp)
@@ -349,16 +349,16 @@ func TestStatusChangeIPAddrRoute(t *testing.T) {
 	// add and test routes
 	t.Log("adding and testing routes")
 	routeObj := ocAddRoute(t, fooOshiftClient, routeName, ns, TestSvc, cname, host, ipAddr)
-	buildRouteKeyAndVerify(t, false, "ADD", cname, ns, routeName, "admin")
+	buildRouteKeyAndVerify(t, false, "ADD", cname, ns, routeName, tenant)
 	verifyInRouteStore(g, acceptedRouteStore, true, routeName, ns, cname, host, ipAddr)
 
 	routeObj.Status.Ingress[0].Conditions[0].Message = newIPAddr
 	ocUpdateRoute(t, fooOshiftClient, ns, cname, routeObj)
-	buildRouteKeyAndVerify(t, false, "UPDATE", cname, ns, routeObj.Name, "admin")
+	buildRouteKeyAndVerify(t, false, "UPDATE", cname, ns, routeObj.Name, tenant)
 	verifyInRouteStore(g, acceptedRouteStore, true, routeName, ns, cname, host, newIPAddr)
 
 	ocDeleteRoute(t, fooOshiftClient, routeName, ns)
-	buildRouteKeyAndVerify(t, false, "DELETE", cname, ns, routeName, "admin")
+	buildRouteKeyAndVerify(t, false, "DELETE", cname, ns, routeName, tenant)
 	verifyInRouteStore(g, acceptedRouteStore, false, routeName, ns, cname, host, newIPAddr)
 	DeleteTestGDPObj(gdp)
 }

--- a/gslb/test/integration/third_party_vips/ingress_test.go
+++ b/gslb/test/integration/third_party_vips/ingress_test.go
@@ -341,3 +341,85 @@ func TestIngressWithDefaultSecretAndRoutesAndTenantUpdate(t *testing.T) {
 	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
 
 }
+
+// Add an ingress and a route with different Tenant from GSLBConfig and empty annotation in namespace
+// Update Tenant Annotations on namespace
+func TestTenantUpdateWithAkoAndAmkoInDifferentTenant(t *testing.T) {
+
+	sitePersistenceRef := "gap-1"
+	RemoveTenantInNamespace("default")
+	gdpObj := GetTestDefaultGDPObject()
+	gdpObj.Spec.MatchRules.AppSelector = gdpalphav2.AppSelector{
+		Label: appLabel,
+	}
+	gdpObj.Spec.MatchClusters = []gdpalphav2.ClusterProperty{
+		{Cluster: K8sContext}, {Cluster: OshiftContext},
+	}
+	gdpObj.Spec.SitePersistenceRef = &sitePersistenceRef
+	newGDP, err := AddAndVerifyTestGDPSuccess(t, gdpObj)
+	if err != nil {
+		t.Fatalf("error in building, adding and verifying app selector GDP: %v", err)
+	}
+
+	testPrefix := "tdr-"
+	ingName := testPrefix + "def-ing"
+	routeName := testPrefix + "def-route"
+	ns := "default"
+	host := testPrefix + ingestion_test.TestDomain1
+	ingIPAddr := "1.1.1.1"
+	routeIPAddr := "2.2.2.2"
+	ingCluster := "k8s"
+	routeCluster := "oshift"
+	ingHostIPMap := map[string]string{host: ingIPAddr}
+	path := []string{"/"}
+
+	t.Cleanup(func() {
+		k8sDeleteIngress(t, clusterClients[K8s], ingName, ns)
+		oshiftDeleteRoute(t, clusterClients[Oshift], routeName, ns)
+		DeleteTestGDP(t, newGDP.Namespace, newGDP.Name)
+		UpdateTenantInNamespace(tenant, "default")
+	})
+
+	initMiddlewares(t)
+	g := gomega.NewGomegaWithT(t)
+	RemoveTenantInNamespace("default")
+	tls := true
+	useDefaultSecret := true
+
+	ingObj := k8sAddIngress(t, clusterClients[K8s], ingName, ns, ingestion_test.TestSvc, ingCluster,
+		ingHostIPMap, path, false, useDefaultSecret)
+	routeObj := oshiftAddRoute(t, clusterClients[Oshift], routeName, ns, ingestion_test.TestSvc,
+		routeCluster, host, routeIPAddr, path[0], true)
+
+	var expectedMembers []nodes.AviGSK8sObj
+	expectedMembers = append(expectedMembers, getTestGSMemberFromIng(t, ingObj, ingCluster, 1, 10))
+	expectedMembers = append(expectedMembers, getTestGSMemberFromRoute(t, routeObj, routeCluster, 1, 10))
+	gslbconfigTenant := "gslbservice"
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, host, gslbconfigTenant, nil, nil, &sitePersistenceRef, nil, nil, nil, path, tls, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	hmNames := BuildTestHmNames(host, path, tls)
+	g.Eventually(func() bool {
+		return verifyGSMembersInRestLayer(t, expectedMembers, host, gslbconfigTenant, hmNames, &sitePersistenceRef, nil, nil, path, tls)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+	newtenant := "tenant2"
+	UpdateTenantInNamespace(newtenant, "default")
+	updateTenantInIngAndRoute(t, clusterClients[K8s], newtenant, ingObj, routeObj)
+	t.Logf("updated tenant in route/ingrees to %s", newtenant)
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, host, newtenant, nil, nil, &sitePersistenceRef, nil, nil, nil, path, tls, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+	g.Eventually(func() bool {
+		return verifyGSMembersInRestLayer(t, expectedMembers, host, newtenant, hmNames, &sitePersistenceRef, nil, nil, path, tls)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+	RemoveTenantInNamespace("default")
+	updateTenantInIngAndRoute(t, clusterClients[K8s], tenant, ingObj, routeObj)
+	t.Logf("updated tenant in route/ingrees to %s", tenant)
+	g.Eventually(func() bool {
+		return verifyGSMembers(t, expectedMembers, host, gslbconfigTenant, nil, nil, &sitePersistenceRef, nil, nil, nil, path, tls, nil)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+	g.Eventually(func() bool {
+		return verifyGSMembersInRestLayer(t, expectedMembers, host, gslbconfigTenant, hmNames, &sitePersistenceRef, nil, nil, path, tls)
+	}, 5*time.Second, 1*time.Second).Should(gomega.Equal(true))
+}


### PR DESCRIPTION
set tenant from gslbconfig if namespacetenant is empty but k8s object contains tenant annotation.

This is a case where tenant of vs  is determined from ako configmap instead of namespace annotation. In this case we should create the GS in the tenant determined from GSLB config of AMKO

```
**********************************************************************************************************************************
*                                          AviTest Test Cases Execution Summary Report                                           *
**********************************************************************************************************************************
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : test/avitest/functional/amko/test_amko_mt1.py    |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| TestAMKOTenant.test_create_setup                                                 |     PASSED     |       00:00:14      |   13:47:55  |   13:48:10  |
| TestAMKOTenant.test_create_gdp_with_priority                                     |     PASSED     |       00:04:49      |   13:48:10  |   13:53:00  |
| TestAMKOTenant.test_create_gslbhostrule_with_hmref                               |     PASSED     |       00:03:55      |   13:53:00  |   13:56:55  |
| TestAMKOTenant.test_clean_setup                                                  |     PASSED     |       00:01:13      |   13:56:55  |   13:58:09  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |    Passed: 4   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 4                                                             |    Skipped:0   | Total Time:00:10:13 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
[2024-11-03 13:59:55] :INFO: [logger_utils timed:58] calc_exc_time: 'display_summary' - 0.01 sec
Rebot framework is generating html file...
Time taken for rebot to generate html file 0.00 seconds

Logs combined. Removing individual logs....
```