### PR TITLE
AV-228104 add hostrule aliases in map during boot-up

### DIFF
--- a/gslb/ingestion/bootup_handler.go
+++ b/gslb/ingestion/bootup_handler.go
@@ -184,8 +184,8 @@ func HandleBootup(cfg *restclient.Config) (bool, error) {
 	}
 
 	if len(amkoClusterList.Items) == 0 {
-		gslbutils.Logf("No AMKOCluster object found, AMKO would start as leader")
-		return true, nil
+		gslbutils.Logf("No AMKOCluster object found, rebooting AMKO")
+		return false, fmt.Errorf("No AMKOCluster object was found")
 	}
 	if len(amkoClusterList.Items) > 1 {
 		return false, fmt.Errorf("only one AMKOClusterObject allowed per cluster")

--- a/gslb/test/bootuptest/bootup_test.go
+++ b/gslb/test/bootuptest/bootup_test.go
@@ -406,6 +406,13 @@ var _ = Describe("AMKO bootup Validation", func() {
 	amkoCluster1 := getTestAMKOClusterObj(Cluster1, true)
 	amkoCluster2 := getTestAMKOClusterObj(Cluster2, true)
 
+	Context("when there is no member cluster", func() {
+		Specify("AMKO Should not boot up", func() {
+			ok, _ := ingestion.HandleBootup(cfg1)
+			Expect(ok).Should(BeFalse())
+		})
+	})
+
 	Context("Both Member clusters are leaders", func() {
 		Specify("AMKO Should not boot up", func() {
 			By("Checking AMKOCLuster object fields of all member clusters")


### PR DESCRIPTION
http://10.80.35.67/cf.html -> FT results for hostrule with customfqdn true
http://10.80.35.67/ns.html ->  FT results for hostrule with customfqdn false

This Pr also fixes AV-228538 where we reboot in case amkocluster item list is empty